### PR TITLE
Enhancements and bugs fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Then, update your project's pom.xml file dependencies, as follows:
 
 ```
   <dependency>
-      <groupId>com.github.krdev.imapnio</groupId>
+      <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>2.0.0</version>
+      <version>3.0.0</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.
@@ -73,10 +73,8 @@ The following code examples demonstrate basic functionality relate to connecting
   config.setReadTimeoutMillis(6000);
   final List<String> sniNames = null;
 
-  final LogManager logManager = new LogManager(Level.DEBUG, LogPage.DEFAULT_SIZE);
-  logManager.setLegacy(true);
   final InetSocketAddress localAddress = null;
-  final Future<ImapAsyncSession> future = aclient.createSession(serverUri, config, localAddress, sniNames);
+  final Future<ImapAsyncCreateSessionResponse> future = imapClient.createSession(serverUri, config, localAddress, sniNames, DebugMode.DEBUG_OFF);
   
   //this version is a future-based nio client.  Check whether future is done by following code.
   if (future.isDone()) {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>2.0.7</version>
+        <version>3.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/client/ImapAsyncSession.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/client/ImapAsyncSession.java
@@ -37,7 +37,7 @@ public interface ImapAsyncSession {
 
     /**
      * Turns on or off the debugging.
-     * 
+     *
      * @param debugMode the debugging mode
      */
     void setDebugMode(DebugMode debugMode);
@@ -50,10 +50,8 @@ public interface ImapAsyncSession {
      * @param command the command request.
      * @return the future object for this command
      * @throws ImapAsyncClientException on failure
-     * @throws IOException when encountering IO exception
-     * @throws SearchException when a search expression cannot be handled, conformed to RFC3501 standard
      */
-    <T> ImapFuture<ImapAsyncResponse> execute(ImapRequest<T> command) throws ImapAsyncClientException, IOException, SearchException;
+    <T> ImapFuture<ImapAsyncResponse> execute(ImapRequest command) throws ImapAsyncClientException;
 
     /**
      * Terminates the current running command.

--- a/core/src/main/java/com/yahoo/imapnio/async/data/MessageNumberSet.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/data/MessageNumberSet.java
@@ -1,0 +1,260 @@
+package com.yahoo.imapnio.async.data;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+/**
+ * This class models seq-range from RFC 3501. ABNF from RFC3501 is documented below. MessageNumberSet array allows to model sequence-set.
+ *
+ * <pre>
+ * {@code
+ * 2.3.1.  Message Numbers
+ *
+ *    Messages in IMAP4rev1 are accessed by one of two numbers; the unique
+ *    identifier or the message sequence number.
+ * ============================================================================
+ * ABNF:
+ * seq-number      = nz-number / "*"
+ *                   ; message sequence number (COPY, FETCH, STORE
+ *                   ; commands) or unique identifier (UID COPY,
+ *                   ; UID FETCH, UID STORE commands).
+ *                   ; * represents the largest number in use.  In
+ *                   ; the case of message sequence numbers, it is
+ *                   ; the number of messages in a non-empty mailbox.
+ *                   ; In the case of unique identifiers, it is the
+ *                   ; unique identifier of the last message in the
+ *                   ; mailbox or, if the mailbox is empty, the
+ *                   ; mailbox's current UIDNEXT value.
+ *                   ; The server should respond with a tagged BAD
+ *                   ; response to a command that uses a message
+ *                   ; sequence number greater than the number of
+ *                   ; messages in the selected mailbox.  This
+ *                   ; includes "*" if the selected mailbox is empty.
+ *
+ * seq-range       = seq-number ":" seq-number
+ *                   ; two seq-number values and all values between
+ *                   ; these two regardless of order.
+ *                   ; Example: 2:4 and 4:2 are equivalent and indicate
+ *                   ; values 2, 3, and 4.
+ *                   ; Example: a unique identifier sequence range of
+ *                   ; 3291:* includes the UID of the last message in
+ *                   ; the mailbox, even if that value is less than 3291.
+ *
+ * sequence-set    = (seq-number / seq-range) *("," sequence-set)
+ *                   ; set of seq-number values, regardless of order.
+ *                   ; Servers MAY coalesce overlaps and/or execute the
+ *                   ; sequence in any order.
+ *                   ; Example: a message sequence number set of
+ *                   ; 2,4:7,9,12:* for a mailbox with 15 messages is
+ *                   ; equivalent to 2,4,5,6,7,9,12,13,14,15
+ *                   ; Example: a message sequence number set of *:4,5:7
+ *                   ; for a mailbox with 10 messages is equivalent to
+ *                   ; 10,9,8,7,6,5,4,5,6,7 and MAY be reordered and
+ *                   ; overlap coalesced to be 4,5,6,7,8,9,10.
+ *
+ * nz-number       = digit-nz *DIGIT
+ *                   ; Non-zero unsigned 32-bit integer
+ *                   ; (0 < n < 4,294,967,296)
+ *
+ * }
+ * </pre>
+ */
+@SuppressWarnings("hideutilityclassconstructor")
+public final class MessageNumberSet {
+
+    /**
+     * Enum for external use to denote last message.
+     */
+    public enum LastMessage {
+        /** Last message. */
+        LAST_MESSAGE
+    }
+
+    /**
+     * Message sequence type. Whether an ending message is an absolute number or last message, or just last message.
+     */
+    private enum SequenceType {
+
+        /** Sequence range ends with an absolute message sequence number, for example: 3:10. */
+        ABSOLUTE_END,
+
+        /** Ends with the last message in the mailbox, for example: 3:* . */
+        LAST_MESSAGE_END,
+
+        /** Only need the last message, aka: * . */
+        LAST_MESSAGE_ONLY
+    };
+
+    /** Sequence type. */
+    private final SequenceType seqType;
+
+    /** Starting message number, could be message sequence or UID. */
+    private final long start;
+
+    /** Ending message number, could be message sequence or UID, if it ends same number as start, it means <seq-number>. */
+    private final long end;
+
+    /**
+     * Instantiates a {@code MessageNumberSet} with specific numeric start and end. For example, 4:10.
+     *
+     * @param start starting message sequence or UID sequence
+     * @param end ending message sequence or UID sequence
+     */
+    public MessageNumberSet(final long start, final long end) {
+        this(start, end, SequenceType.ABSOLUTE_END);
+    }
+
+    /**
+     * Instantiates a {@code MessageNumberSet} that starts with given start message number and ends with last message.
+     *
+     * @param start starting message sequence or UID sequence
+     * @param lastMsgFlag flag to denote that it is the last message in mailbox
+     */
+    public MessageNumberSet(final long start, @Nonnull final LastMessage lastMsgFlag) {
+        this(start, start, SequenceType.LAST_MESSAGE_END);
+    }
+
+    /**
+     * Instantiates a sequence that only returns last message, aka, * .
+     *
+     * @param lastMsgFlag enum to denote whether it is a last message, should always be
+     * @throws ImapAsyncClientException when given isLastMessageOnly is false
+     */
+    public MessageNumberSet(@Nonnull final LastMessage lastMsgFlag) throws ImapAsyncClientException {
+        if (lastMsgFlag != LastMessage.LAST_MESSAGE) {
+            throw new ImapAsyncClientException(ImapAsyncClientException.FailureType.INVALID_INPUT);
+        }
+        this.start = -1;
+        this.end = -1;
+        this.seqType = SequenceType.LAST_MESSAGE_ONLY;
+    }
+
+    /**
+     * Instantiates a {@code MessageNumberSet} with start value, end value and SequenceType option.
+     *
+     * @param start starting message sequence or UID sequence
+     * @param end ending message sequence or UID sequence
+     * @param seqType ending option either a specific/absolute value, or last message as the end
+     */
+    private MessageNumberSet(final long start, final long end, @Nonnull final SequenceType seqType) {
+        this.start = start < end ? start : end; // ensure smaller at the start
+        this.end = start < end ? end : start; // ensure larger at the end
+        this.seqType = seqType;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hc = 1;
+        hc = prime * hc + seqType.name().hashCode();
+        hc = prime * hc + Long.hashCode(start);
+        hc = prime * hc + Long.hashCode(end);
+        return hc;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof MessageNumberSet) {
+            final MessageNumberSet o = (MessageNumberSet) obj;
+            return (o.seqType == seqType) && (start == o.start) && (end == o.end);
+        }
+        return false;
+    }
+
+    /**
+     * Converts an array of integers into an array of MessageNumberSet. This is a helper method for callers with int array.
+     *
+     * @param msgs array of primitive integer data type message number (could be message sequence or UID)
+     * @return MessageNumberSet array
+     */
+    public static MessageNumberSet[] createMessageNumberSets(@Nonnull final int[] msgs) {
+        final List<MessageNumberSet> v = new ArrayList<MessageNumberSet>();
+        int i = 0;
+        while (i < msgs.length) {
+            int start = msgs[i];
+            // Look for contiguous elements
+            int j = i + 1;
+            while (j < msgs.length && msgs[j] == msgs[j - 1] + 1) {
+                j++;
+            }
+            int end = msgs[j - 1];
+            v.add(new MessageNumberSet(start, end));
+            i = j;
+        }
+        return v.toArray(new MessageNumberSet[v.size()]);
+    }
+
+    /**
+     * Converts an array of long into array of MessageNumberSet. This is a helper method for callers with long array.
+     *
+     * @param msgs array of long data type message number (could be message sequence or UID)
+     * @return the string generated that conforms to RFC3501 Message Number syntax
+     */
+    public static MessageNumberSet[] createMessageNumberSets(@Nonnull final long[] msgs) {
+        final List<MessageNumberSet> v = new ArrayList<MessageNumberSet>();
+        int i = 0;
+        while (i < msgs.length) {
+            long start = msgs[i];
+            // Look for contiguous elements
+            int j = i + 1;
+            while (j < msgs.length && msgs[j] == msgs[j - 1] + 1) {
+                j++;
+            }
+            long end = msgs[j - 1];
+            v.add(new MessageNumberSet(start, end));
+            i = j;
+        }
+        return v.toArray(new MessageNumberSet[v.size()]);
+    }
+
+    /**
+     * Converts an array of MessageNumberSet into an IMAP RFC3501 sequence-set syntax.
+     *
+     * @param msgsets array of MessageNumberSet
+     * @return the string generated that conforms to IMAP RFC3501 sequence-set syntax
+     */
+    public static String buildString(@Nullable final MessageNumberSet[] msgsets) {
+        if (msgsets == null || msgsets.length == 0) {
+            return null;
+        }
+
+        // remove duplicates
+        final Set<MessageNumberSet> elems = new LinkedHashSet<>(Arrays.asList(msgsets));
+
+        int i = 0; // msgset index
+        final StringBuilder s = new StringBuilder();
+        final int size = elems.size();
+        long start, end;
+
+        for (final MessageNumberSet elem : elems) {
+            start = elem.start;
+            end = elem.end;
+
+            if (elem.seqType == SequenceType.LAST_MESSAGE_ONLY) {
+                s.append('*');
+            } else if (elem.seqType == SequenceType.LAST_MESSAGE_END) {
+                s.append(start).append(':').append('*');
+            } else if (end > start) {
+                s.append(start).append(':').append(end);
+            } else { // end == start means only one element
+                s.append(start);
+            }
+
+            i++; // increment to next round
+            if (i >= size) { // No more MessageNumberSet objects
+                break;
+            } else {
+                s.append(',');
+            }
+        }
+        return s.toString();
+    }
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/data/SearchResult.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/data/SearchResult.java
@@ -1,0 +1,33 @@
+package com.yahoo.imapnio.async.data;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class provides the list of message sequence numbers from search command response.
+ */
+public class SearchResult {
+    /** Search command response sequence number, could be message sequence or UID. */
+    @Nullable
+    private final List<Long> msgNumbers;
+
+    /**
+     * Initializes a {@code SearchResult} object with message number collection.
+     *
+     * @param msgNumbers collection of message number from search command result
+     */
+    public SearchResult(@Nullable final List<Long> msgNumbers) {
+        // make it immutable here so we avoid keeping creating UnmodifiableList whenever getter is called
+        this.msgNumbers = (msgNumbers != null) ? Collections.unmodifiableList(msgNumbers) : null;
+    }
+
+    /**
+     * @return message number collection from search command or UID search command result
+     */
+    @Nullable
+    public List<Long> getMessageNumbers() {
+        return this.msgNumbers;
+    }
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/internal/CompressCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/internal/CompressCommand.java
@@ -1,6 +1,7 @@
 package com.yahoo.imapnio.async.internal;
 
 import com.yahoo.imapnio.async.request.AbstractNoArgsCommand;
+import com.yahoo.imapnio.async.request.ImapCommandType;
 
 /**
  * This class defines imap Compress request from client.
@@ -13,12 +14,16 @@ final class CompressCommand extends AbstractNoArgsCommand {
     private static final String COMPRESS_DEFLATE = "COMPRESS DEFLATE";
 
     /**
-     * Initializes the @{code COMPRESS_DEFLATECommand}. Constructor is only visible to this package so it can only be called by @{code
-     * ImapAsyncSessionImpl}.
+     * Initializes the @{code CompressCommand}. Constructor is only visible to this package so it can only be called by @{code ImapAsyncSessionImpl}.
      * 
      * @see "RFC 4978"
      */
     CompressCommand() {
         super(COMPRESS_DEFLATE);
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.COMPRESS;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/AbstractFetchCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/AbstractFetchCommand.java
@@ -1,0 +1,132 @@
+package com.yahoo.imapnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines IMAP fetch command request from client. ABNF in RFC3501 is described as following:
+ *
+ * <pre>
+ * {@code
+ * fetch           = "FETCH" SP sequence-set SP ("ALL" / "FULL" / "FAST" /
+ *                   fetch-att / "(" fetch-att *(SP fetch-att) ")")
+ *
+ * fetch-att       = "ENVELOPE" / "FLAGS" / "INTERNALDATE" /
+ *                   "RFC822" [".HEADER" / ".SIZE" / ".TEXT"] /
+ *                   "BODY" ["STRUCTURE"] / "UID" /
+ *                   "BODY" section ["<" number "." nz-number ">"] /
+ *                   "BODY.PEEK" section ["<" number "." nz-number ">"]
+ * }
+ * </pre>
+ */
+public abstract class AbstractFetchCommand extends ImapRequestAdapter {
+
+    /** FETCH and space. */
+    private static final String FETCH_SP = "FETCH ";
+
+    /** Byte array for FETCH. */
+    private static final byte[] FETCH_SP_B = FETCH_SP.getBytes(StandardCharsets.US_ASCII);
+
+    /** UID FETCH and space. */
+    private static final String UID_FETCH_SP = "UID FETCH ";
+
+    /** Byte array for UID FETCH. */
+    private static final byte[] UID_FETCH_SP_B = UID_FETCH_SP.getBytes(StandardCharsets.US_ASCII);
+
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
+    /** Message numbers, either message sequence or UID. */
+    private String msgNumbers;
+
+    /** Fetch items. */
+    private String dataItems;
+
+    /** Fetch macro. */
+    private FetchMacro macro;
+
+    /** True if prepending UID; false otherwise. */
+    private boolean isUid;
+
+    /**
+     * Initializes a @{code FetchCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param isUid whether prepending UID
+     * @param msgsets the set of message set
+     * @param items the data items
+     */
+    public AbstractFetchCommand(final boolean isUid, @Nonnull final MessageNumberSet[] msgsets, @Nonnull final String items) {
+        this(isUid, MessageNumberSet.buildString(msgsets), items);
+    }
+
+    /**
+     * Initializes a @{code FetchCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param isUid whether prepending UID
+     * @param msgsets the set of message set
+     * @param macro the macro
+     */
+    public AbstractFetchCommand(final boolean isUid, @Nonnull final MessageNumberSet[] msgsets, @Nonnull final FetchMacro macro) {
+        this(isUid, MessageNumberSet.buildString(msgsets), macro);
+    }
+
+    /**
+     * Initializes a @{code FetchCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param isUid whether prepending UID
+     * @param msgNumbers the message numbers string
+     * @param items the data items
+     */
+    protected AbstractFetchCommand(final boolean isUid, @Nonnull final String msgNumbers, @Nonnull final String items) {
+        this.isUid = isUid;
+        this.msgNumbers = msgNumbers;
+        this.dataItems = items;
+        this.macro = null;
+    }
+
+    /**
+     * Initializes a @{code FetchCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param isUid whether prepending UID
+     * @param msgNumbers the message numbers string
+     * @param macro the macro
+     */
+    protected AbstractFetchCommand(final boolean isUid, @Nonnull final String msgNumbers, @Nonnull final FetchMacro macro) {
+        this.isUid = isUid;
+        this.msgNumbers = msgNumbers;
+        this.macro = macro;
+        this.dataItems = null;
+    }
+
+    @Override
+    public void cleanup() {
+        this.msgNumbers = null;
+        this.dataItems = null;
+        this.macro = null;
+    }
+
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        final ByteBuf sb = Unpooled.buffer();
+        sb.writeBytes(isUid ? UID_FETCH_SP_B : FETCH_SP_B);
+        sb.writeBytes(msgNumbers.getBytes(StandardCharsets.US_ASCII));
+        sb.writeByte(ImapClientConstants.SPACE);
+
+        if (dataItems != null) {
+            sb.writeByte(ImapClientConstants.L_PAREN);
+            sb.writeBytes(dataItems.getBytes(StandardCharsets.US_ASCII));
+            sb.writeByte(ImapClientConstants.R_PAREN);
+        } else {
+            sb.writeBytes(macro.name().getBytes(StandardCharsets.US_ASCII));
+        }
+        sb.writeBytes(CRLF_B);
+
+        return sb;
+    }
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/AbstractFolderActionCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/AbstractFolderActionCommand.java
@@ -1,13 +1,22 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.BASE64MailboxEncoder;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * This class defines imap abstract commands related to change operation on folder, like create folder, rename folder, delete folder.
  */
 abstract class AbstractFolderActionCommand extends ImapRequestAdapter {
+
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
 
     /** Command operator, for example, "CREATE". */
     private String op;
@@ -33,18 +42,19 @@ abstract class AbstractFolderActionCommand extends ImapRequestAdapter {
     }
 
     @Override
-    public String getCommandLine() {
+    public ByteBuf getCommandLineBytes() throws ImapAsyncClientException {
 
         final String base64Folder = BASE64MailboxEncoder.encode(folderName);
         // 2 * base64Folder.length(): assuming every char needs to be escaped, goal is eliminating resizing, and avoid complex length calculation
         final int len = 2 * base64Folder.length() + ImapClientConstants.PAD_LEN;
-        final StringBuilder sb = new StringBuilder(len).append(op);
-        sb.append(ImapClientConstants.SPACE);
+        final ByteBuf sb = Unpooled.buffer(len);
+        sb.writeBytes(op.getBytes(StandardCharsets.US_ASCII));
+        sb.writeByte(ImapClientConstants.SPACE);
 
         final ImapArgumentFormatter formatter = new ImapArgumentFormatter();
         formatter.formatArgument(base64Folder, sb, false); // already base64 encoded so can be formatted and write to sb
-        sb.append(ImapClientConstants.CRLF);
+        sb.writeBytes(CRLF_B);
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/AbstractMessageActionCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/AbstractMessageActionCommand.java
@@ -1,17 +1,30 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.BASE64MailboxEncoder;
 import com.sun.mail.imap.protocol.MessageSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * This class defines imap message change operation command from client. For example, copy message, move message.
  */
 abstract class AbstractMessageActionCommand extends ImapRequestAdapter {
 
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
     /** UID and space. */
     private static final String UID_SPACE = "UID ";
+
+    /** Byte array for UID. */
+    private static final byte[] UID_B = UID_SPACE.getBytes(StandardCharsets.US_ASCII);
 
     /** The command. */
     private String op;
@@ -20,7 +33,7 @@ abstract class AbstractMessageActionCommand extends ImapRequestAdapter {
     private boolean isUid;
 
     /** A collection of messages specified based on RFC3501 syntax. */
-    private String msgset;
+    private String msgNumbers;
 
     /** The destination folder for the email to copy to. */
     private String targetFolder;
@@ -36,6 +49,19 @@ abstract class AbstractMessageActionCommand extends ImapRequestAdapter {
     protected AbstractMessageActionCommand(@Nonnull final String op, final boolean isUid, @Nonnull final MessageSet[] msgsets,
             @Nonnull final String targetFolder) {
         this(op, isUid, MessageSet.toString(msgsets), targetFolder);
+    }
+
+    /**
+     * Initializes a @{code MessageActionCommand} with the message sequence syntax.
+     *
+     * @param op the command
+     * @param isUid true if it is a uid sequence
+     * @param msgsets the set of @{code MessageNumberSet}
+     * @param targetFolder the targetFolder to be stored
+     */
+    protected AbstractMessageActionCommand(@Nonnull final String op, final boolean isUid, @Nonnull final MessageNumberSet[] msgsets,
+            @Nonnull final String targetFolder) {
+        this(op, isUid, MessageNumberSet.buildString(msgsets), targetFolder);
     }
 
     /**
@@ -58,44 +84,47 @@ abstract class AbstractMessageActionCommand extends ImapRequestAdapter {
      *
      * @param op the command
      * @param isUid true if it is a uid sequence
-     * @param msgset the messages set string
+     * @param msgNumbers the messages set string
      * @param targetFolder the targetFolder to be stored
      */
-    protected AbstractMessageActionCommand(@Nonnull final String op, final boolean isUid, @Nonnull final String msgset,
+    protected AbstractMessageActionCommand(@Nonnull final String op, final boolean isUid, @Nonnull final String msgNumbers,
             @Nonnull final String targetFolder) {
         this.op = op;
         this.isUid = isUid;
-        this.msgset = msgset;
+        this.msgNumbers = msgNumbers;
         this.targetFolder = targetFolder;
     }
 
     @Override
     public void cleanup() {
         this.op = null;
-        this.msgset = null;
+        this.msgNumbers = null;
         this.targetFolder = null;
     }
 
     @Override
-    public String getCommandLine() {
+    public ByteBuf getCommandLineBytes() throws ImapAsyncClientException {
 
         // encode the mbox as per RFC2060
         final String base64Folder = BASE64MailboxEncoder.encode(targetFolder);
         // 2 * base64Folder.length(): assuming every char needs to be escaped, goal is eliminating resizing, and avoid complex length calculation
         final int len = 2 * base64Folder.length() + ImapClientConstants.PAD_LEN;
-        final StringBuilder sb = new StringBuilder(len);
+        final ByteBuf sb = Unpooled.buffer(len);
 
         if (isUid) {
-            sb.append(UID_SPACE);
+            sb.writeBytes(UID_B);
         }
 
-        sb.append(op).append(ImapClientConstants.SPACE).append(msgset).append(ImapClientConstants.SPACE);
+        sb.writeBytes(op.getBytes(StandardCharsets.US_ASCII));
+        sb.writeByte(ImapClientConstants.SPACE);
+        sb.writeBytes(msgNumbers.getBytes(StandardCharsets.US_ASCII));
+        sb.writeByte(ImapClientConstants.SPACE);
 
         final ImapArgumentFormatter argWriter = new ImapArgumentFormatter();
         argWriter.formatArgument(base64Folder, sb, false);
 
-        sb.append(ImapClientConstants.CRLF);
+        sb.writeBytes(CRLF_B);
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/AbstractNoArgsCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/AbstractNoArgsCommand.java
@@ -1,11 +1,19 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.annotation.Nonnull;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * This class defines an Imap command that has no arguments sent from client.
  */
 public abstract class AbstractNoArgsCommand extends ImapRequestAdapter {
+
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
 
     /** The Command. */
     private String op;
@@ -26,9 +34,12 @@ public abstract class AbstractNoArgsCommand extends ImapRequestAdapter {
     }
 
     @Override
-    public String getCommandLine() {
+    public ByteBuf getCommandLineBytes() {
         final int len = op.length() + ImapClientConstants.CRLFLEN;
-        return new StringBuilder(len).append(op).append(ImapClientConstants.CRLF).toString();
+        final ByteBuf sb = Unpooled.buffer(len);
+        sb.writeBytes(op.getBytes(StandardCharsets.US_ASCII));
+        sb.writeBytes(CRLF_B);
+        return sb;
     }
 
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/AbstractSearchCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/AbstractSearchCommand.java
@@ -1,0 +1,194 @@
+package com.yahoo.imapnio.async.request;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.mail.internet.MimeUtility;
+import javax.mail.search.SearchException;
+import javax.mail.search.SearchTerm;
+
+import com.sun.mail.iap.Argument;
+import com.sun.mail.iap.ProtocolException;
+import com.sun.mail.imap.protocol.SearchSequence;
+import com.yahoo.imapnio.async.data.Capability;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException.FailureType;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines IMAP search command request from client.
+ *
+ * <pre>
+ * search         = "SEARCH" [SP "CHARSET" SP astring] 1*(SP search-key)
+ *                   ; CHARSET argument to MUST be registered with IANA
+ *
+ * search-key     = "ALL" / "ANSWERED" / "BCC" SP astring /
+ *                  "BEFORE" SP date / "BODY" SP astring /
+ *                  "CC" SP astring / "DELETED" / "FLAGGED" /
+ *                  "FROM" SP astring / "KEYWORD" SP flag-keyword /
+ *                  "NEW" / "OLD" / "ON" SP date / "RECENT" / "SEEN" /
+ *                  "SINCE" SP date / "SUBJECT" SP astring /
+ *                  "TEXT" SP astring / "TO" SP astring /
+ *                  "UNANSWERED" / "UNDELETED" / "UNFLAGGED" /
+ *                  "UNKEYWORD" SP flag-keyword / "UNSEEN" /
+ *                    ; Above this line were in [IMAP2]
+ *                  "DRAFT" / "HEADER" SP header-fld-name SP astring /
+ *                  "LARGER" SP number / "NOT" SP search-key /
+ *                  "OR" SP search-key SP search-key /
+ *                  "SENTBEFORE" SP date / "SENTON" SP date /
+ *                  "SENTSINCE" SP date / "SMALLER" SP number /
+ *                  "UID" SP sequence-set / "UNDRAFT" / sequence-set /
+ *                  "(" search-key *(SP search-key) ")"
+ * </pre>
+ */
+public abstract class AbstractSearchCommand extends ImapRequestAdapter {
+
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
+    /** Character set literal. */
+    private static final String CHARSET = "CHARSET";
+
+    /** Charset literal following by a space. */
+    private static final byte[] CHARSET_B = CHARSET.getBytes(StandardCharsets.US_ASCII);
+
+    /** SEARCH . */
+    private static final String SEARCH = "SEARCH";
+
+    /** SEARCH in byte array. */
+    private static final byte[] SEARCH_B = SEARCH.getBytes(StandardCharsets.US_ASCII);
+
+    /** UID SEARCH. */
+    private static final String UID_SEARCH = "UID SEARCH";
+
+    /** UID SEARCH in byte array. */
+    private static final byte[] UID_SEARCH_B = UID_SEARCH.getBytes(StandardCharsets.US_ASCII);
+
+    /** Flag whether adding UID before search. */
+    private boolean isUid;
+
+    /** Message numbers in string type, specified based on RFC3501 sequence-set syntax. */
+    private String msgNumbers;
+
+    /** The search expression. */
+    private Argument searchExpr;
+
+    /** Character set. */
+    private String charset;
+
+    /** flag whether server allows LITERAL+. */
+    private boolean isLiteralPlusEnabled;
+
+    /**
+     * Initializes the object with the MessageNumberSet array, search string and character set name.
+     *
+     * @param isUid whether it is UID Search command
+     * @param msgsets the set of MessageNumberSet
+     * @param term the search string
+     * @param capa the capability instance to find if it has literal
+     * @throws ImapAsyncClientException when both msgsets and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
+     */
+    protected AbstractSearchCommand(final boolean isUid, @Nullable final MessageNumberSet[] msgsets, @Nullable final SearchTerm term,
+            @Nullable final Capability capa) throws ImapAsyncClientException, SearchException, IOException {
+        this(isUid, MessageNumberSet.buildString(msgsets), term, capa);
+    }
+
+    /**
+     * Initializes the object with the string form of message sequence, search string and character set name.
+     *
+     * @param isUid whether it is UID Search command
+     * @param msgNumbers the set of MessageNumberSet
+     * @param term the search term
+     * @param capa the capability instance to find if it has literal
+     * @throws ImapAsyncClientException when both msgsets and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
+     */
+    protected AbstractSearchCommand(final boolean isUid, @Nullable final String msgNumbers, @Nullable final SearchTerm term,
+            @Nullable final Capability capa) throws ImapAsyncClientException, SearchException, IOException {
+        // based on [ABNF] above, 1*(SP search-key), cannot have both null
+        if (msgNumbers == null && term == null) {
+            throw new ImapAsyncClientException(FailureType.INVALID_INPUT);
+        }
+        this.isUid = isUid;
+        this.msgNumbers = msgNumbers;
+
+        // maintain same semantic with IMAPProtocol, but we do not retry when fail in various of charsets. we only use UTF_8
+        this.charset = SearchSequence.isAscii(term) ? null : StandardCharsets.UTF_8.name();
+
+        if (term != null) {
+            final SearchSequence searchSeq = new SearchSequence();
+            this.searchExpr = searchSeq.generateSequence(term, charset == null ? null : MimeUtility.javaCharset(charset));
+        }
+        this.isLiteralPlusEnabled = (capa != null) ? capa.hasCapability(ImapClientConstants.LITERAL_PLUS) : false;
+    }
+
+    /**
+     * Initializes the object with the string form of message sequence, search string and character set name.
+     *
+     * @param isUid whether it is UID Search command
+     * @param msgNumbers the set of MessageNumberSet
+     * @param charset the character set
+     * @param args the argument containing the search term
+     * @param capa the capability instance to find if it has literal
+     * @throws ImapAsyncClientException when both msgsets and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
+     */
+    protected AbstractSearchCommand(final boolean isUid, @Nullable final String msgNumbers, @Nullable final String charset,
+            @Nonnull final Argument args, @Nullable final Capability capa) throws ImapAsyncClientException, SearchException, IOException {
+        // based on [ABNF] above, 1*(SP search-key), cannot have both null
+        if (msgNumbers == null && args == null) {
+            throw new ImapAsyncClientException(FailureType.INVALID_INPUT);
+        }
+
+        this.isUid = isUid;
+        this.msgNumbers = msgNumbers;
+        this.charset = charset;
+        this.searchExpr = args;
+        this.isLiteralPlusEnabled = (capa != null) ? capa.hasCapability(ImapClientConstants.LITERAL_PLUS) : false;
+    }
+
+    @Override
+    public void cleanup() {
+        this.msgNumbers = null;
+        this.searchExpr = null;
+        this.charset = null;
+    }
+
+    @Override
+    public ByteBuf getCommandLineBytes() throws ImapAsyncClientException {
+        final ByteBuf sb = Unpooled.buffer();
+        sb.writeBytes(isUid ? UID_SEARCH_B : SEARCH_B);
+
+        if (charset != null) {
+            sb.writeByte(ImapClientConstants.SPACE);
+            sb.writeBytes(CHARSET_B);
+            sb.writeByte(ImapClientConstants.SPACE);
+            sb.writeBytes(charset.getBytes(StandardCharsets.US_ASCII));
+        }
+
+        if (msgNumbers != null) {
+            sb.writeByte(ImapClientConstants.SPACE);
+            sb.writeBytes(msgNumbers.getBytes(StandardCharsets.US_ASCII));
+        }
+
+        if (searchExpr != null) {
+            sb.writeByte(ImapClientConstants.SPACE);
+            try {
+                searchExpr.write(new ByteBufWriter(sb, isLiteralPlusEnabled));
+            } catch (final IOException | ProtocolException e) {
+                throw new ImapAsyncClientException(FailureType.INVALID_INPUT, e);
+            }
+        }
+        sb.writeBytes(CRLF_B);
+        return sb;
+    }
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/AbstractStoreFlagsCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/AbstractStoreFlagsCommand.java
@@ -1,0 +1,148 @@
+package com.yahoo.imapnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+import javax.mail.Flags;
+
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines imap store command request from client, with formal syntax below.
+ *
+ * <pre>
+ *
+ * store           = "STORE" SP sequence-set SP store-att-flags
+ *
+ * store-att-flags = (["+" / "-"] "FLAGS" [".SILENT"]) SP
+ *                   (flag-list / (flag *(SP flag)))
+ * flag-list       = "(" [flag *(SP flag)] ")"
+ * flag            = "\Answered" / "\Flagged" / "\Deleted" /
+ *                   "\Seen" / "\Draft" / flag-keyword / flag-extension
+ *                   ; Does not include "\Recent"
+ *
+ * flag-extension  = "\" atom
+ *                   ; Future expansion.  Client implementations
+ *                   ; MUST accept flag-extension flags.  Server
+ *                   ; implementations MUST NOT generate
+ *                   ; flag-extension flags except as defined by
+ *                   ; future standard or standards-track
+ *                   ; revisions of this specification.
+ * </pre>
+ */
+public abstract class AbstractStoreFlagsCommand extends ImapRequestAdapter {
+
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
+    /** Literal for STORE. */
+    private static final String STORE_SP = "STORE ";
+
+    /** Byte array for STORE. */
+    private static final byte[] STORE_SP_B = STORE_SP.getBytes(StandardCharsets.US_ASCII);
+
+    /** Literal for UID STORE. */
+    private static final String UID_STORE_SP = "UID STORE ";
+
+    /** Byte array for UID STORE. */
+    private static final byte[] UID_STORE_SP_B = UID_STORE_SP.getBytes(StandardCharsets.US_ASCII);
+
+    /** Literal for FLAGS. */
+    private static final String FLAGS = "FLAGS";
+
+    /** Byte array for FLAGS. */
+    private static final byte[] FLAGS_B = FLAGS.getBytes(StandardCharsets.US_ASCII);
+
+    /** Literal for .SILENT to append after FLAGS. */
+    private static final String SILENT = ".SILENT";
+
+    /** Byte array for SILENT. */
+    private static final byte[] SILENT_B = SILENT.getBytes(StandardCharsets.US_ASCII);
+
+    /** Flag whether adding UID before store command. */
+    private boolean isUid;
+
+    /** A collection of messages numbers specified based on RFC3501 sequence-set syntax. */
+    private String msgNumbers;
+
+    /** Messages flags. */
+    private Flags flags;
+
+    /** Action to indicate whether to add, replace or remove existing flag. */
+    private FlagsAction action;
+
+    /** Flag to indicate whether silent or not. */
+    private final boolean isSilent;
+
+    /**
+     * Initializes a @{code AbstractStoreFlagsCommand} with the MessageNumberSet array, flags, action and silent flag whether server should return new
+     * values.
+     *
+     * @param isUid whether to have UID prepended
+     * @param msgsets the set of message set
+     * @param flags the flags to be stored
+     * @param action whether to replace, add or remove the flags
+     * @param silent true if asking server to respond silently
+     */
+    protected AbstractStoreFlagsCommand(final boolean isUid, @Nonnull final MessageNumberSet[] msgsets, @Nonnull final Flags flags,
+            @Nonnull final FlagsAction action, final boolean silent) {
+        this(isUid, MessageNumberSet.buildString(msgsets), flags, action, silent);
+    }
+
+    /**
+     * Initializes a @{code AbstractStoreFlagsCommand} with string form message numbers (could be sequence sets or UIDs) and all other parameters.
+     *
+     * @param isUid whether to have UID prepended
+     * @param msgNumbers the message id
+     * @param flags the flags to be stored
+     * @param action whether to replace, add or remove the flags
+     * @param silent true if asking server to respond silently
+     */
+    protected AbstractStoreFlagsCommand(final boolean isUid, @Nonnull final String msgNumbers, @Nonnull final Flags flags,
+            @Nonnull final FlagsAction action, final boolean silent) {
+        this.isUid = isUid;
+        this.msgNumbers = msgNumbers;
+        this.flags = flags;
+        this.action = action;
+        this.isSilent = silent;
+    }
+
+    @Override
+    public void cleanup() {
+        this.msgNumbers = null;
+        this.flags = null;
+        this.action = null;
+    }
+
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        // Ex:STORE 2:4 +FLAGS (\Deleted)
+        final ByteBuf sb = Unpooled.buffer();
+        sb.writeBytes(isUid ? UID_STORE_SP_B : STORE_SP_B);
+        sb.writeBytes(msgNumbers.getBytes(StandardCharsets.US_ASCII));
+        sb.writeByte(ImapClientConstants.SPACE);
+
+        if (action == FlagsAction.ADD) {
+            sb.writeByte(ImapClientConstants.PLUS);
+        } else if (action == FlagsAction.REMOVE) {
+            sb.writeByte(ImapClientConstants.MINUS);
+        }
+
+        sb.writeBytes(FLAGS_B);
+
+        if (isSilent) {
+            sb.writeBytes(SILENT_B);
+        }
+
+        // buildFlagString generates "(" [flag *(SP flag)] ")"
+        final ImapArgumentFormatter argWriter = new ImapArgumentFormatter();
+        sb.writeByte(ImapClientConstants.SPACE);
+        sb.writeBytes(argWriter.buildFlagString(flags).getBytes(StandardCharsets.US_ASCII));
+        sb.writeBytes(CRLF_B);
+
+        return sb;
+    }
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ByteBufWriter.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ByteBufWriter.java
@@ -1,0 +1,99 @@
+package com.yahoo.imapnio.async.request;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
+
+import javax.annotation.Nonnull;
+
+import com.sun.mail.iap.Protocol;
+import com.sun.mail.iap.ProtocolException;
+import com.sun.mail.iap.Response;
+import com.sun.mail.imap.protocol.IMAPResponse;
+import com.sun.mail.util.MailLogger;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * This class allows writing the data from argument to ByteBuf directly.
+ */
+final class ByteBufWriter extends Protocol {
+
+    /** Symbol to indicate continue response. */
+    private static final String CONTINUE_SYMBOL = "+";
+
+    /** The OutputStream used by ByteBufWriter. */
+    private OutputStream outputStream;
+
+    /** Flag to indicate whether literal plus is enabled. */
+    private boolean isLiteralPlus;
+
+    /**
+     * Creates a ByteBufWriter object.
+     *
+     * @throws IOException on failure
+     */
+    ByteBufWriter(@Nonnull final ByteBuf buf, final boolean isLiteralPlus) throws IOException {
+        super(null, null, new Properties(), false);
+        this.outputStream = new ByteBufOutputStream(buf);
+        this.isLiteralPlus = isLiteralPlus;
+    }
+
+    /**
+     * Never used but must be implemented.
+     *
+     * @param host IMAP server host
+     * @param port IMAP server port
+     * @param props properties
+     * @param prefix prefix to prepend property keys
+     * @param isSSL is this an SSL connection
+     * @param logger logger
+     * @throws IOException on network failure
+     * @throws ProtocolException on IMAP protocol errors
+     */
+    private ByteBufWriter(final String host, final int port, final Properties props, final String prefix, final boolean isSSL,
+            final MailLogger logger) throws IOException, ProtocolException {
+        super(host, port, props, prefix, isSSL, logger);
+    }
+
+    /**
+     * Returns a continuation response in order to avoid @{code com.sun.mail.iap.Argument} blocking on literal method to wait for server continuation.
+     */
+    @Override
+    public Response readResponse() throws IOException, ProtocolException {
+        return new IMAPResponse(CONTINUE_SYMBOL);
+    }
+
+    @Override
+    protected OutputStream getOutputStream() {
+        return new DataOutputStream(outputStream);
+    }
+
+    @Override
+    protected synchronized boolean supportsNonSyncLiterals() {
+        return isLiteralPlus;
+    }
+}
+
+/**
+ * ByteBufOutputStream that allows writing to ByteBuf directly.
+ */
+class ByteBufOutputStream extends OutputStream {
+    /** Internal buffer. */
+    private ByteBuf buf;
+
+    /**
+     * Instantiates ByteBufOutputStream instance with ByteBuf.
+     *
+     * @param buf ByteBuf instance
+     */
+    ByteBufOutputStream(@Nonnull final ByteBuf buf) {
+        this.buf = buf;
+    }
+
+    @Override
+    public void write(final int b) throws IOException {
+        buf.writeByte(b);
+    }
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/CapaCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/CapaCommand.java
@@ -14,4 +14,9 @@ public class CapaCommand extends AbstractNoArgsCommand {
     public CapaCommand() {
         super(CAPABILITY);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.CAPABILITY;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/CheckCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/CheckCommand.java
@@ -14,4 +14,9 @@ public class CheckCommand extends AbstractNoArgsCommand {
     public CheckCommand() {
         super(CHECK);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.CHECK;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/CloseCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/CloseCommand.java
@@ -14,4 +14,9 @@ public class CloseCommand extends AbstractNoArgsCommand {
     public CloseCommand() {
         super(CLOSE);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.CLOSE;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/CopyMessageCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/CopyMessageCommand.java
@@ -3,6 +3,7 @@ package com.yahoo.imapnio.async.request;
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.MessageSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines imap copy command from client.
@@ -31,5 +32,20 @@ public class CopyMessageCommand extends AbstractMessageActionCommand {
      */
     public CopyMessageCommand(final int start, final int end, @Nonnull final String targetFolder) {
         super(COPY, false, start, end, targetFolder);
+    }
+
+    /**
+     * Initializes a @{code CopyMessageCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param msgsets the set of @{code MessageNumberSet}
+     * @param targetFolder the targetFolder to be stored
+     */
+    public CopyMessageCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final String targetFolder) {
+        super(COPY, false, msgsets, targetFolder);
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.COPY_MESSAGE;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/CreateFolderCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/CreateFolderCommand.java
@@ -18,4 +18,9 @@ public class CreateFolderCommand extends AbstractFolderActionCommand {
     public CreateFolderCommand(@Nonnull final String folderName) {
         super(CREATE, folderName);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.CREATE_FOLDER;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/DeleteFolderCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/DeleteFolderCommand.java
@@ -18,4 +18,9 @@ public class DeleteFolderCommand extends AbstractFolderActionCommand {
     public DeleteFolderCommand(@Nonnull final String folderName) {
         super(DELETE, folderName);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.DELETE_FOLDER;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ExamineFolderCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ExamineFolderCommand.java
@@ -20,4 +20,9 @@ public class ExamineFolderCommand extends AbstractFolderActionCommand {
     public ExamineFolderCommand(@Nonnull final String folderName) {
         super(EXAMINE, folderName);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.EXAMINE_FOLDER;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ExpungeCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ExpungeCommand.java
@@ -14,4 +14,9 @@ public class ExpungeCommand extends AbstractNoArgsCommand {
     public ExpungeCommand() {
         super(EXPUNGE);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.EXPUNGE;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/FetchCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/FetchCommand.java
@@ -2,66 +2,35 @@ package com.yahoo.imapnio.async.request;
 
 import javax.annotation.Nonnull;
 
-import com.sun.mail.imap.protocol.MessageSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines imap fetch command request from client.
  */
-public class FetchCommand extends ImapRequestAdapter {
-
-    /** FETCH and space. */
-    private static final String FETCH_SPACE = "FETCH ";
-
-    /** Message Id, either message sequence or UID. */
-    private String msgIds;
-
-    /** Fetch items. */
-    private String dataItems;
+public class FetchCommand extends AbstractFetchCommand {
 
     /**
-     * Initializes a @{code FetchCommand} with the message sequence syntax.
+     * Initializes a @{code FetchCommand} with the @{code MessageNumberSet} array and fetch items.
      *
      * @param msgsets the set of message set
-     * @param what the data items or macro
+     * @param items the data items
      */
-    public FetchCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final String what) {
-        this(MessageSet.toString(msgsets), what);
+    public FetchCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final String items) {
+        super(false, msgsets, items);
     }
 
     /**
-     * Initializes a @{code FetchCommand} with the start and end message sequence.
+     * Initializes a @{code FetchCommand} with the @{code MessageNumberSet} array and macro.
      *
-     * @param msgStart the starting message sequence
-     * @param msgEnd the ending message sequence
-     * @param what the data items or macro
+     * @param msgsets the set of message set
+     * @param macro the macro
      */
-    public FetchCommand(final int msgStart, final int msgEnd, @Nonnull final String what) {
-        this(new StringBuilder(String.valueOf(msgStart)).append(ImapClientConstants.COLON).append(String.valueOf(msgEnd)).toString(), what);
-    }
-
-    /**
-     * Initializes a @{code FetchCommand} with the message sequence syntax.
-     *
-     * @param msgIds the message sequence or UID string. For ex:2:4
-     * @param what the data items or macro
-     */
-    private FetchCommand(@Nonnull final String msgIds, @Nonnull final String what) {
-        this.msgIds = msgIds;
-        this.dataItems = what;
+    public FetchCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final FetchMacro macro) {
+        super(false, msgsets, macro);
     }
 
     @Override
-    public void cleanup() {
-        this.msgIds = null;
-        this.dataItems = null;
-    }
-
-    @Override
-    public String getCommandLine() {
-        final StringBuilder sb = new StringBuilder(dataItems.length() + ImapClientConstants.PAD_LEN).append(FETCH_SPACE).append(msgIds)
-                .append(ImapClientConstants.SPACE).append(ImapClientConstants.L_PAREN).append(dataItems).append(ImapClientConstants.R_PAREN)
-                .append(ImapClientConstants.CRLF);
-
-        return sb.toString();
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.FETCH;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/FetchMacro.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/FetchMacro.java
@@ -1,0 +1,13 @@
+package com.yahoo.imapnio.async.request;
+
+/**
+ * Macro for fetch command.
+ */
+public enum FetchMacro {
+    /** Fetch macro for ALL. */
+    ALL,
+    /** Fetch macro for FULL. */
+    FULL,
+    /** Fetch macro for FAST. */
+    FAST
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/FlagsAction.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/FlagsAction.java
@@ -1,0 +1,13 @@
+package com.yahoo.imapnio.async.request;
+
+/**
+ * Flags action used for store command.
+ */
+public enum FlagsAction {
+    /** Replace the flags given in the flags list for the message. */
+    REPLACE,
+    /** Add the flags given in the flags list for the message. */
+    ADD,
+    /** Remove the flags given in the flags list for the message. */
+    REMOVE
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/IdCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/IdCommand.java
@@ -1,14 +1,29 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * This class defines imap id command request from client.
  */
 public class IdCommand extends ImapRequestAdapter {
 
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
+    /** NIL literal byte array. */
+    private static final byte[] NIL_B = { 'N', 'I', 'L' };
+
     /** ID and space. */
-    private static final String ID_SPACE = "ID ";
+    private static final String ID_SP = "ID ";
+
+    /** Byte array for ID and space. */
+    private static final byte[] ID_SP_B = ID_SP.getBytes(StandardCharsets.US_ASCII);
 
     /** ID command line initial space. */
     private static final int IDLINE_LEN = 200;
@@ -31,31 +46,37 @@ public class IdCommand extends ImapRequestAdapter {
     }
 
     @Override
-    public String getCommandLine() {
-        final StringBuilder sb = new StringBuilder(IDLINE_LEN).append(ID_SPACE);
+    public ByteBuf getCommandLineBytes() throws ImapAsyncClientException {
+        final ByteBuf sb = Unpooled.buffer(IDLINE_LEN);
+        sb.writeBytes(ID_SP_B);
 
         if (params == null) {
-            sb.append(ImapClientConstants.NIL);
+            sb.writeBytes(NIL_B);
         } else {
             // every token has to be encoded (double quoted and escaped) if needed
             // ex: a023 ID ("name" "so/"dr" "version" "19.34")
             final ImapArgumentFormatter formatter = new ImapArgumentFormatter();
-            sb.append(ImapClientConstants.L_PAREN);
+            sb.writeByte(ImapClientConstants.L_PAREN);
             boolean isFirstEntry = true;
             for (final Map.Entry<String, String> e : params.entrySet()) {
                 if (!isFirstEntry) {
-                    sb.append(ImapClientConstants.SPACE);
+                    sb.writeByte(ImapClientConstants.SPACE);
                 } else {
                     isFirstEntry = false;
                 }
                 formatter.formatArgument(e.getKey(), sb, true);
-                sb.append(ImapClientConstants.SPACE);
+                sb.writeByte(ImapClientConstants.SPACE);
                 formatter.formatArgument(e.getValue(), sb, true);
             }
-            sb.append(ImapClientConstants.R_PAREN);
+            sb.writeByte(ImapClientConstants.R_PAREN);
         }
 
-        sb.append(ImapClientConstants.CRLF);
-        return sb.toString();
+        sb.writeBytes(CRLF_B);
+        return sb;
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.ID;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ImapClientConstants.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ImapClientConstants.java
@@ -1,49 +1,49 @@
 package com.yahoo.imapnio.async.request;
 
-
 /**
- * Class for constant string in the IMAP Async client.
+ * Class for constant string in the IMAP asynchronous client.
  */
-public final class ImapClientConstants {
+final class ImapClientConstants {
 
     /** Space character. */
-    public static final char SPACE = ' ';
+    static final char SPACE = ' ';
 
     /** String for CR and LF. */
-    public static final String CRLF = "\r\n";
+    static final String CRLF = "\r\n";
 
     /** Literal for CR and LF. */
-    public static final int CRLFLEN = "\r\n".length();
+    static final int CRLFLEN = "\r\n".length();
 
     /** NULL character. */
-    public static final char NULL = '\0';
+    static final char NULL = '\0';
 
     /** Start of header character. */
-    public static final char SOH = 0x01;
+    static final char SOH = 0x01;
 
-    /** Left paraenthsisand space. */
-    public static final char L_PAREN = '(';
+    /** Left parenthesis and space. */
+    static final char L_PAREN = '(';
 
-    /** Left paraenthsisand space. */
-    public static final char R_PAREN = ')';
+    /** Left parenthesis and space. */
+    static final char R_PAREN = ')';
 
     /** Literal for colon. */
-    public static final String COLON = ":";
+    static final String COLON = ":";
 
     /** Literal for plus. */
-    public static final char PLUS = '+';
+    static final char PLUS = '+';
 
     /** Literal for minus. */
-    public static final char MINUS = '-';
-
-    /** NIL literal. */
-    public static final String NIL = "NIL";
+    static final char MINUS = '-';
 
     /** SASL-IR capability. */
-    public static final String SASL_IR = "SASL-IR";
+    static final String SASL_IR = "SASL-IR";
+
+    /** LITERAL+ capability. */
+    static final String LITERAL_PLUS = "LITERAL+";
 
     /** Extra buffer length for command line builder to add. */
-    public static final int PAD_LEN = 100;;
+    static final int PAD_LEN = 100;;
+
     /**
      * Private constructor to avoid constructing instance of this class.
      */

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ImapCommandType.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ImapCommandType.java
@@ -1,0 +1,77 @@
+package com.yahoo.imapnio.async.request;
+
+/**
+ * IMAP command types.
+ */
+public enum ImapCommandType {
+    /** Append message command. */
+    APPEND_MESSAGE,
+    /** Authenticate plain command. */
+    AUTH_PLAIN,
+    /** Authenticate XOAUTH2 command. */
+    AUTH_XOAUTH2,
+    /** Capability command. */
+    CAPABILITY,
+    /** Check command. */
+    CHECK,
+    /** Close command. */
+    CLOSE,
+    /** Compress command. */
+    COMPRESS,
+    /** Copy message command. */
+    COPY_MESSAGE,
+    /** Create folder command. */
+    CREATE_FOLDER,
+    /** Delete folder command. */
+    DELETE_FOLDER,
+    /** Examine folder command. */
+    EXAMINE_FOLDER,
+    /** Expunge command. */
+    EXPUNGE,
+    /** Fetch command. */
+    FETCH,
+    /** Id command. */
+    ID,
+    /** Idle command. */
+    IDLE,
+    /** List command. */
+    LIST,
+    /** Login command. */
+    LOGIN,
+    /** Logout command. */
+    LOGOUT,
+    /** LSUB command. */
+    LSUB,
+    /** Move message command. */
+    MOVE_MESSAGE,
+    /** Noop command. */
+    NOOP,
+    /** Rename folder command. */
+    RENAME_FOLDER,
+    /** Search command. */
+    SEARCH,
+    /** Select folder command. */
+    SELECT_FOLDER,
+    /** Status command. */
+    STATUS,
+    /** Store flags command. */
+    STORE_FLAGS,
+    /** Subscribe command. */
+    SUBSCRIBE,
+    /** UID copy command. */
+    UID_COPY_MESSAGE,
+    /** UID expunge command. */
+    UID_EXPUNGE,
+    /** UID fetch command. */
+    UID_FETCH,
+    /** UID move command. */
+    UID_MOVE_MESSAGE,
+    /** UID search command. */
+    UID_SEARCH,
+    /** UID store command. */
+    UID_STORE_FLAGS,
+    /** Unselect command. */
+    UNSELECT,
+    /** Unsubscribe command. */
+    UNSUBSCRIBE
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ImapRequest.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ImapRequest.java
@@ -1,37 +1,48 @@
 package com.yahoo.imapnio.async.request;
 
-import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.annotation.Nonnull;
-import javax.mail.search.SearchException;
 
 import org.apache.avro.reflect.Nullable;
 
 import com.sun.mail.imap.protocol.IMAPResponse;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * This class defines an Imap command sent from client.
- *
- * @param <T> the data type for next command after continuation.
  */
-public interface ImapRequest<T> {
+public interface ImapRequest {
     /**
      * @return true if the command line data is sensitive; false otherwise
      */
     boolean isCommandLineDataSensitive();
 
     /**
-     * Builds the command line for this command - the line to be sent over wire.
+     * Builds the command line in bytes - the line to be sent over wire.
      *
-     * @return command line
-     * @throws SearchException when Search command expression does not conform to standard
-     * @throws IOException for I/O errors
+     * @return command line in binary form
      * @throws ImapAsyncClientException when encountering an error in building terminate command line
      */
     @Nonnull
-    String getCommandLine() throws SearchException, IOException, ImapAsyncClientException;
+    ByteBuf getCommandLineBytes() throws ImapAsyncClientException;
+
+    /**
+     * Builds the command line for this command - the line to be sent over wire.
+     *
+     * @return command line
+     * @throws ImapAsyncClientException when encountering an error in building terminate command line
+     */
+    @Nonnull
+    String getCommandLine() throws ImapAsyncClientException;
+
+    /**
+     * @return IMAP command type
+     */
+    @Nullable
+    ImapCommandType getCommandType();
 
     /**
      * @return log data appropriate for the command
@@ -47,13 +58,13 @@ public interface ImapRequest<T> {
 
     /**
      * Builds the next command line after server challenge.
-     * 
+     *
      * @param serverResponse the server response
      * @throws ImapAsyncClientException when building command line encounters an error
      * @return command line
      */
     @Nullable
-    T getNextCommandLineAfterContinuation(@Nonnull IMAPResponse serverResponse) throws ImapAsyncClientException;
+    ByteBuf getNextCommandLineAfterContinuation(@Nonnull IMAPResponse serverResponse) throws ImapAsyncClientException;
 
     /**
      * Builds the next command line after server challenge.
@@ -62,7 +73,7 @@ public interface ImapRequest<T> {
      * @return command line
      */
     @Nullable
-    String getTerminateCommandLine() throws ImapAsyncClientException;
+    ByteBuf getTerminateCommandLine() throws ImapAsyncClientException;
 
     /**
      * Avoids loitering.

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ImapRequestAdapter.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ImapRequestAdapter.java
@@ -1,5 +1,6 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.annotation.Nonnull;
@@ -8,14 +9,21 @@ import com.sun.mail.imap.protocol.IMAPResponse;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException.FailureType;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * This class is an adapter for commands with no continuation request or terminal request.
  */
-public abstract class ImapRequestAdapter implements ImapRequest<String> {
+public abstract class ImapRequestAdapter implements ImapRequest {
 
     @Override
     public boolean isCommandLineDataSensitive() {
         return false;
+    }
+
+    @Override
+    public String getCommandLine() throws ImapAsyncClientException {
+        return getCommandLineBytes().toString(StandardCharsets.US_ASCII);
     }
 
     @Override
@@ -29,12 +37,12 @@ public abstract class ImapRequestAdapter implements ImapRequest<String> {
     }
 
     @Override
-    public String getNextCommandLineAfterContinuation(@Nonnull final IMAPResponse serverResponse) throws ImapAsyncClientException {
+    public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final IMAPResponse serverResponse) throws ImapAsyncClientException {
         throw new ImapAsyncClientException(FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
     }
 
     @Override
-    public String getTerminateCommandLine() throws ImapAsyncClientException {
+    public ByteBuf getTerminateCommandLine() throws ImapAsyncClientException {
         throw new ImapAsyncClientException(FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/LSubCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/LSubCommand.java
@@ -19,4 +19,9 @@ public class LSubCommand extends AbstractQueryFoldersCommand {
     public LSubCommand(@Nonnull final String ref, @Nonnull final String pattern) {
         super(LSUB, ref, pattern);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.LSUB;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ListCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ListCommand.java
@@ -19,4 +19,9 @@ public class ListCommand extends AbstractQueryFoldersCommand {
     public ListCommand(@Nonnull final String ref, @Nonnull final String pattern) {
         super(LIST, ref, pattern);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.LIST;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/LiteralSupport.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/LiteralSupport.java
@@ -1,0 +1,13 @@
+package com.yahoo.imapnio.async.request;
+
+/**
+ * Literal support variation.
+ */
+public enum LiteralSupport {
+    /** Use Literal+ support to send literals. */
+    ENABLE_LITERAL_PLUS,
+    /** Use Literal- support to send literals. */
+    ENABLE_LITERAL_MINUS,
+    /** Disabling using literal support, just use standard RFC3501 specifications. */
+    DISABLE
+}

--- a/core/src/main/java/com/yahoo/imapnio/async/request/LoginCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/LoginCommand.java
@@ -1,14 +1,27 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.annotation.Nonnull;
+
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * This class defines IMAP login command request from client.
  */
 public class LoginCommand extends ImapRequestAdapter {
 
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
     /** Literal for Login and space. */
-    private static final String LOGIN_SPACE = "LOGIN ";
+    private static final String LOGIN_SP = "LOGIN ";
+
+    /** Byte array for LOGIN. */
+    private static final byte[] LOGIN_SP_B = LOGIN_SP.getBytes(StandardCharsets.US_ASCII);
 
     /** Literal for logging data. */
     private static final String LOG_PREFIX = "LOGIN FOR USER:";
@@ -37,9 +50,19 @@ public class LoginCommand extends ImapRequestAdapter {
     }
 
     @Override
-    public String getCommandLine() {
-        return new StringBuilder(LOGIN_SPACE).append(username).append(ImapClientConstants.SPACE).append(dwp).append(ImapClientConstants.CRLF)
-                .toString();
+    public ByteBuf getCommandLineBytes() throws ImapAsyncClientException {
+
+        final ByteBuf sb = Unpooled.buffer(username.length() + dwp.length() + ImapClientConstants.PAD_LEN);
+        sb.writeBytes(LOGIN_SP_B);
+
+        final ImapArgumentFormatter formatter = new ImapArgumentFormatter();
+        formatter.formatArgument(username, sb, false);
+        sb.writeByte(ImapClientConstants.SPACE);
+
+        formatter.formatArgument(dwp, sb, false);
+        sb.writeBytes(CRLF_B);
+
+        return sb;
     }
 
     @Override
@@ -50,5 +73,10 @@ public class LoginCommand extends ImapRequestAdapter {
     @Override
     public String getDebugData() {
         return new StringBuilder(LOG_PREFIX).append(username).toString();
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.LOGIN;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/LogoutCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/LogoutCommand.java
@@ -14,4 +14,9 @@ public class LogoutCommand extends AbstractNoArgsCommand {
     public LogoutCommand() {
         super(LOGOUT);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.LOGOUT;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/MoveMessageCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/MoveMessageCommand.java
@@ -3,6 +3,7 @@ package com.yahoo.imapnio.async.request;
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.MessageSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines imap move command request from client.
@@ -31,5 +32,20 @@ public class MoveMessageCommand extends AbstractMessageActionCommand {
      */
     public MoveMessageCommand(final int start, final int end, @Nonnull final String targetFolder) {
         super(MOVE, false, start, end, targetFolder);
+    }
+
+    /**
+     * Initializes a @{code CopyMessageCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param msgsets the set of @{code MessageNumberSet}
+     * @param targetFolder the targetFolder to be stored
+     */
+    public MoveMessageCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final String targetFolder) {
+        super(MOVE, false, msgsets, targetFolder);
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.MOVE_MESSAGE;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/NoopCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/NoopCommand.java
@@ -14,4 +14,9 @@ public class NoopCommand extends AbstractNoArgsCommand {
     public NoopCommand() {
         super(NOOP);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.NOOP;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/SearchCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/SearchCommand.java
@@ -1,80 +1,70 @@
 package com.yahoo.imapnio.async.request;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
-import javax.mail.internet.MimeUtility;
+import javax.annotation.Nullable;
 import javax.mail.search.SearchException;
 import javax.mail.search.SearchTerm;
 
-import com.sun.mail.imap.protocol.MessageSet;
-import com.sun.mail.imap.protocol.SearchSequence;
-import com.yahoo.imapnio.command.Argument;
+import com.sun.mail.iap.Argument;
+import com.yahoo.imapnio.async.data.Capability;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
 
 /**
  * This class defines IMAP search command request from client.
  */
-public class SearchCommand extends ImapRequestAdapter {
-
-    /** Charset literal following by a space. */
-    private static final String CHARSET = "CHARSET ";
-
-    /** Command name. */
-    private static final String SEARCH_SP = "SEARCH ";
-
-    /** A collection of messages specified based on RFC3501 syntax. */
-    private String msgIds;
-
-    /** The search expression tree. */
-    private SearchTerm term;
+public class SearchCommand extends AbstractSearchCommand {
 
     /**
-     * Initializes a @{code SearchCommand} object with required parameters.
+     * Initializes a @{code SearchCommand} with the MessageNumberSet array, search string and character set name.
      *
-     * @param msgsets the set of message set
-     * @param term the search expression tree
+     * @param msgsets the set of MessageNumberSet
+     * @param term the search term
+     * @param capa the capability instance to check if it has literal
+     * @throws ImapAsyncClientException when both msgsets and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
      */
-    public SearchCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final SearchTerm term) {
-        this(MessageSet.toString(msgsets), term);
+    public SearchCommand(@Nullable final MessageNumberSet[] msgsets, @Nullable final SearchTerm term, @Nullable final Capability capa)
+            throws ImapAsyncClientException, SearchException, IOException {
+        super(false, msgsets, term, capa);
     }
 
     /**
-     * Initializes a @{code SearchCommand} with the msg string directly.
+     * Initializes this object with the string form of message sequence, search string and character set name.
      *
-     * @param msgIds the messages id string
-     * @param term the search expression tree
+     * @param msgNumbers the string type message numbers in sequence-set syntax
+     * @param term the search term
+     * @param capa the capability instance to check if it has literal
+     * @throws ImapAsyncClientException when both msgNumber and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
      */
-    private SearchCommand(@Nonnull final String msgIds, @Nonnull final SearchTerm term) {
-        this.msgIds = msgIds;
-        this.term = term;
+    public SearchCommand(@Nullable final String msgNumbers, @Nullable final SearchTerm term, @Nullable final Capability capa)
+            throws ImapAsyncClientException, SearchException, IOException {
+        super(false, msgNumbers, term, capa);
+    }
+
+    /**
+     * Initializes this object with the string form of message sequence, character set name, and Argument that expresses the search term.
+     *
+     * @param msgNumbers the string form message numbers in sequence-set syntax
+     * @param charset the character set
+     * @param args the search term in argument format
+     * @param capa the capability instance to check if it has literal
+     * @throws ImapAsyncClientException when both msgNumber and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
+     */
+    public SearchCommand(@Nullable final String msgNumbers, @Nullable final String charset, @Nonnull final Argument args,
+            @Nullable final Capability capa) throws ImapAsyncClientException, SearchException, IOException {
+        super(false, msgNumbers, charset, args, capa);
     }
 
     @Override
-    public void cleanup() {
-        this.msgIds = null;
-        this.term = null;
-    }
-
-    @Override
-    public String getCommandLine() throws SearchException, IOException {
-        // maintain same semantic with IMAPProtocol, but we do not retry when fail in various of charsets. we only use UTF_8
-        final String charset = SearchSequence.isAscii(term) ? null : StandardCharsets.UTF_8.name();
-
-        // convert from search expression tree to String
-        final SearchSequence searchSeq = new SearchSequence();
-        final Argument args = new Argument();
-        args.append(searchSeq.generateSequence(term, charset == null ? null : MimeUtility.javaCharset(charset)));
-        args.writeAtom(msgIds);
-
-        final String searchStr = args.toString();
-
-        final StringBuilder sb = new StringBuilder(searchStr.length() + ImapClientConstants.PAD_LEN).append(SEARCH_SP);
-
-        if (charset != null) {
-            sb.append(CHARSET).append(charset).append(ImapClientConstants.SPACE);
-        }
-        sb.append(searchStr).append(ImapClientConstants.CRLF);
-        return sb.toString();
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.SEARCH;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/SelectFolderCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/SelectFolderCommand.java
@@ -18,4 +18,9 @@ public class SelectFolderCommand extends AbstractFolderActionCommand {
     public SelectFolderCommand(@Nonnull final String folderName) {
         super(SELECT, folderName);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.SELECT_FOLDER;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/StatusCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/StatusCommand.java
@@ -1,16 +1,35 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.BASE64MailboxEncoder;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
- * This class defines imap status command request from client.
+ * This class defines imap status command request from client. RFC 3501 ABNF for status command.
+ *
+ * <pre>
+ * status          = "STATUS" SP mailbox SP
+ *                   "(" status-att *(SP status-att) ")"
+ * status-att      = "MESSAGES" / "RECENT" / "UIDNEXT" / "UIDVALIDITY" /
+ *                   "UNSEEN"
+ * </pre>
  */
 public class StatusCommand extends ImapRequestAdapter {
 
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
     /** Status and space. */
-    private static final String STATUS_SPACE = "STATUS ";
+    private static final String STATUS_SP = "STATUS ";
+
+    /** Byte array for STATUS. */
+    private static final byte[] STATUS_SP_B = STATUS_SP.getBytes(StandardCharsets.US_ASCII);
 
     /** Folder name. */
     private String folderName;
@@ -36,25 +55,33 @@ public class StatusCommand extends ImapRequestAdapter {
     }
 
     @Override
-    public String getCommandLine() {
+    public ByteBuf getCommandLineBytes() throws ImapAsyncClientException {
+
+        final ByteBuf sb = Unpooled.buffer(ImapClientConstants.PAD_LEN);
         // ex: STATUS "test1" (UIDNEXT MESSAGES UIDVALIDITY RECENT)
-        final StringBuilder sb = new StringBuilder(STATUS_SPACE);
+        sb.writeBytes(STATUS_SP_B);
 
         final ImapArgumentFormatter formatter = new ImapArgumentFormatter();
 
         final String encoded64Folder = BASE64MailboxEncoder.encode(folderName);
         formatter.formatArgument(encoded64Folder, sb, false); // already base64 encoded so can be formatted and write to sb
 
-        sb.append(ImapClientConstants.SPACE).append(ImapClientConstants.L_PAREN);
+        sb.writeByte(ImapClientConstants.SPACE);
+        sb.writeByte(ImapClientConstants.L_PAREN);
         for (int i = 0, len = items.length; i < len; i++) {
             formatter.formatArgument(items[i], sb, false);
             if (i < len - 1) { // do not add space for last item
-                sb.append(ImapClientConstants.SPACE);
+                sb.writeByte(ImapClientConstants.SPACE);
             }
         }
-        sb.append(ImapClientConstants.R_PAREN);
+        sb.writeByte(ImapClientConstants.R_PAREN);
 
-        sb.append(ImapClientConstants.CRLF);
-        return sb.toString();
+        sb.writeBytes(CRLF_B);
+        return sb;
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.STATUS;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/StoreFlagsCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/StoreFlagsCommand.java
@@ -3,79 +3,52 @@ package com.yahoo.imapnio.async.request;
 import javax.annotation.Nonnull;
 import javax.mail.Flags;
 
-import com.sun.mail.imap.protocol.MessageSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines imap store command request from client.
  */
-public class StoreFlagsCommand extends ImapRequestAdapter {
-
-    /** Literal for STORE. */
-    private static final String STORE_SP = "STORE ";
-
-    /** Literal for FLAGS. */
-    private static final String FLAGS_SP = "FLAGS ";
-
-    /** A collection of messages id specified based on RFC3501 syntax. */
-    private String msgIds;
-
-    /** Messages flags. */
-    private Flags flags;
-
-    /** Flag to indicate whether to add or remove existing. */
-    private final boolean isSet;
+public class StoreFlagsCommand extends AbstractStoreFlagsCommand {
 
     /**
-     * Initializes a @{code StoreFlagsCommand} with the MessageSet array.
+     * Initializes a @{code StoreFlagsCommand} with the MessageNumberSet array, Flags and action.Requests server to return the new value.
      *
      * @param msgsets the set of message set
      * @param flags the flags to be stored
-     * @param set true if the specified flags are to be set, false to clear them
+     * @param action whether to replace, add or remove the flags
      */
-    public StoreFlagsCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final Flags flags, final boolean set) {
-        this(MessageSet.toString(msgsets), flags, set);
+    public StoreFlagsCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final Flags flags, @Nonnull final FlagsAction action) {
+        super(false, msgsets, flags, action, false);
     }
 
     /**
-     * Initializes a @{code StoreFlagsCommand} with the start and end message sequence.
+     * Initializes a @{code StoreFlagsCommand} with the MessageNumberSet array and flags.
      *
-     * @param start the starting message sequence
-     * @param end the ending message sequence
+     * @param msgsets the set of message set
      * @param flags the flags to be stored
-     * @param set true if the specified flags are to be set, false to clear them
+     * @param action whether to replace, add or remove the flags
+     * @param silent true if asking server to respond silently
      */
-    public StoreFlagsCommand(final int start, final int end, @Nonnull final Flags flags, final boolean set) {
-        this(new StringBuilder(String.valueOf(start)).append(ImapClientConstants.COLON).append(String.valueOf(end)).toString(), flags, set);
+    public StoreFlagsCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final Flags flags, @Nonnull final FlagsAction action,
+            final boolean silent) {
+        super(false, msgsets, flags, action, silent);
     }
 
     /**
-     * Initializes a @{code StoreFlagsCommand} with the msg string directly.
+     * Initializes a @{code StoreFlagsCommand} with string form message numbers, Flags, action, flag whether to request server to return the new
+     * value.
      *
-     * @param msgset the messages set
+     * @param msgNumbers the message numbers in string format
      * @param flags the flags to be stored
-     * @param set true if the specified flags are to be set, false to clear them
+     * @param action whether to replace, add or remove the flags
+     * @param silent true if asking server to respond silently; false if requesting server to return the new values
      */
-    private StoreFlagsCommand(@Nonnull final String msgset, @Nonnull final Flags flags, final boolean set) {
-        this.msgIds = msgset;
-        this.flags = flags;
-        this.isSet = set;
+    public StoreFlagsCommand(@Nonnull final String msgNumbers, @Nonnull final Flags flags, @Nonnull final FlagsAction action, final boolean silent) {
+        super(false, msgNumbers, flags, action, silent);
     }
 
     @Override
-    public void cleanup() {
-        this.msgIds = null;
-        this.flags = null;
-    }
-
-    @Override
-    public String getCommandLine() {
-        // Ex:STORE 2:4 +FLAGS (\Deleted)
-        final ImapArgumentFormatter argWriter = new ImapArgumentFormatter();
-        final StringBuilder sb = new StringBuilder(STORE_SP).append(msgIds).append(ImapClientConstants.SPACE);
-
-        sb.append(isSet ? ImapClientConstants.PLUS : ImapClientConstants.MINUS).append(FLAGS_SP).append(argWriter.buildFlagString(flags))
-                .append(ImapClientConstants.CRLF);
-
-        return sb.toString();
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.STORE_FLAGS;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/SubscribeFolderCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/SubscribeFolderCommand.java
@@ -18,4 +18,9 @@ public class SubscribeFolderCommand extends AbstractFolderActionCommand {
     public SubscribeFolderCommand(@Nonnull final String folderName) {
         super(SUBSCRIBE, folderName);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.SUBSCRIBE;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UidCopyMessageCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UidCopyMessageCommand.java
@@ -3,6 +3,7 @@ package com.yahoo.imapnio.async.request;
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines IMAP uid copy command from client.
@@ -30,5 +31,20 @@ public class UidCopyMessageCommand extends AbstractMessageActionCommand {
      */
     public UidCopyMessageCommand(@Nonnull final String uids, @Nonnull final String targetFolder) {
         super(COPY, true, uids, targetFolder);
+    }
+
+    /**
+     * Initializes a @{code UidCopyMessageCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param msgsets the set of @{code MessageNumberSet}
+     * @param targetFolder the targetFolder to be stored
+     */
+    public UidCopyMessageCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final String targetFolder) {
+        super(COPY, true, msgsets, targetFolder);
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UID_COPY_MESSAGE;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UidExpungeCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UidExpungeCommand.java
@@ -1,16 +1,28 @@
 package com.yahoo.imapnio.async.request;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * This class defines IMAP UID EXPUNGE command from client.
  */
 public class UidExpungeCommand extends ImapRequestAdapter {
 
+    /** Byte array for CR and LF, keeping the array local so it cannot be modified by others. */
+    private static final byte[] CRLF_B = { '\r', '\n' };
+
     /** Command name. */
     private static final String UID_EXPUNGE = "UID EXPUNGE";
+
+    /** Byte array for UID EXPUNGE. */
+    private static final byte[] UID_EXPUNGE_B = UID_EXPUNGE.getBytes(StandardCharsets.US_ASCII);
 
     /** Message Id, aka UID. */
     private String uids;
@@ -22,6 +34,15 @@ public class UidExpungeCommand extends ImapRequestAdapter {
      */
     public UidExpungeCommand(@Nonnull final UIDSet[] uidsets) {
         this(UIDSet.toString(uidsets));
+    }
+
+    /**
+     * Initializes a @{code UidExpungeCommand} with the message sequence syntax. MessageNumberSet allows last message.
+     *
+     * @param uidsets the set of MessageNumberSet representing UID based on RFC3501
+     */
+    public UidExpungeCommand(@Nonnull final MessageNumberSet[] uidsets) {
+        this(MessageNumberSet.buildString(uidsets));
     }
 
     /**
@@ -39,7 +60,17 @@ public class UidExpungeCommand extends ImapRequestAdapter {
     }
 
     @Override
-    public String getCommandLine() {
-        return new StringBuilder(UID_EXPUNGE).append(ImapClientConstants.SPACE).append(uids).append(ImapClientConstants.CRLF).toString();
+    public ByteBuf getCommandLineBytes() {
+        final ByteBuf buf = Unpooled.buffer(UID_EXPUNGE.length() + uids.length() + ImapClientConstants.PAD_LEN);
+        buf.writeBytes(UID_EXPUNGE_B);
+        buf.writeByte(ImapClientConstants.SPACE);
+        buf.writeBytes(uids.getBytes(StandardCharsets.US_ASCII));
+        buf.writeBytes(CRLF_B);
+        return buf;
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UID_EXPUNGE;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UidFetchCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UidFetchCommand.java
@@ -2,55 +2,55 @@ package com.yahoo.imapnio.async.request;
 
 import javax.annotation.Nonnull;
 
-import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines IMAP UID fetch command request from client.
  */
-public class UidFetchCommand extends ImapRequestAdapter {
-
-    /** UID FETCH and space. */
-    private static final String UID_FETCH_SPACE = "UID FETCH ";
-
-    /** Message UID. */
-    private String uids;
-
-    /** Fetch items. */
-    private String dataItems;
+public class UidFetchCommand extends AbstractFetchCommand {
 
     /**
-     * Initializes a @{code UidFetchCommand} with the message sequence syntax.
+     * Initializes a @{code UidFetchCommand} with the @{code MessageNumberSet} array.
      *
-     * @param uidsets the set of UID set
-     * @param what the data items or macro
+     * @param msgsets the set of message set
+     * @param items the data items
      */
-    public UidFetchCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final String what) {
-        this(UIDSet.toString(uidsets), what);
+    public UidFetchCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final String items) {
+        super(true, msgsets, items);
     }
 
     /**
-     * Initializes a @{code UidFetchCommand} with the message sequence syntax.
+     * Initializes a @{code UidFetchCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param msgsets the set of message set
+     * @param macro the macro, for example, ALL
+     */
+    public UidFetchCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final FetchMacro macro) {
+        super(true, msgsets, macro);
+    }
+
+    /**
+     * Initializes a @{code UidFetchCommand} with string form uids and data items.
      *
      * @param uids the UID string following the RFC3501 syntax. For ex:3857529045,3857529047:3857529065
-     * @param what the data items or macro
+     * @param items the data items
      */
-    public UidFetchCommand(@Nonnull final String uids, @Nonnull final String what) {
-        this.uids = uids;
-        this.dataItems = what;
+    public UidFetchCommand(@Nonnull final String uids, @Nonnull final String items) {
+        super(true, uids, items);
+    }
+
+    /**
+     * Initializes a @{code UidFetchCommand} with string form uids and macro.
+     *
+     * @param uids the UID string following the RFC3501 syntax. For ex:3857529045,3857529047:3857529065
+     * @param macro the macro, for example, ALL
+     */
+    public UidFetchCommand(@Nonnull final String uids, @Nonnull final FetchMacro macro) {
+        super(true, uids, macro);
     }
 
     @Override
-    public void cleanup() {
-        this.uids = null;
-        this.dataItems = null;
-    }
-
-    @Override
-    public String getCommandLine() {
-        final StringBuilder sb = new StringBuilder(dataItems.length() + ImapClientConstants.PAD_LEN).append(UID_FETCH_SPACE).append(uids)
-                .append(ImapClientConstants.SPACE).append(ImapClientConstants.L_PAREN).append(dataItems).append(ImapClientConstants.R_PAREN)
-                .append(ImapClientConstants.CRLF);
-
-        return sb.toString();
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UID_FETCH;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UidMoveMessageCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UidMoveMessageCommand.java
@@ -3,6 +3,7 @@ package com.yahoo.imapnio.async.request;
 import javax.annotation.Nonnull;
 
 import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines imap move command request from client.
@@ -30,5 +31,20 @@ public class UidMoveMessageCommand extends AbstractMessageActionCommand {
      */
     public UidMoveMessageCommand(@Nonnull final String uids, @Nonnull final String targetFolder) {
         super(MOVE, true, uids, targetFolder);
+    }
+
+    /**
+     * Initializes a @{code UidMoveMessageCommand} with the @{code MessageNumberSet} array.
+     *
+     * @param msgsets the set of @{code MessageNumberSet}
+     * @param targetFolder the targetFolder to be stored
+     */
+    public UidMoveMessageCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final String targetFolder) {
+        super(MOVE, true, msgsets, targetFolder);
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UID_MOVE_MESSAGE;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UidSearchCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UidSearchCommand.java
@@ -1,80 +1,70 @@
 package com.yahoo.imapnio.async.request;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
-import javax.mail.internet.MimeUtility;
+import javax.annotation.Nullable;
 import javax.mail.search.SearchException;
 import javax.mail.search.SearchTerm;
 
-import com.sun.mail.imap.protocol.SearchSequence;
-import com.sun.mail.imap.protocol.UIDSet;
-import com.yahoo.imapnio.command.Argument;
+import com.sun.mail.iap.Argument;
+import com.yahoo.imapnio.async.data.Capability;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
 
 /**
  * This class defines IMAP UID search command request from client.
  */
-public class UidSearchCommand extends ImapRequestAdapter {
-
-    /** Charset literal following by a space. */
-    private static final String CHARSET = "CHARSET ";
-
-    /** UID SEARCH and space. */
-    private static final String UID_SEARCH_SPACE = "UID SEARCH ";
-
-    /** A collection of message UID specified based on RFC3501 syntax. */
-    private String uids;
-
-    /** The search expression tree. */
-    private SearchTerm term;
+public class UidSearchCommand extends AbstractSearchCommand {
 
     /**
-     * Initializes a @{code UidSearchCommand} object with required parameters.
+     * Initializes this object with the MessageNumberSet array, search string and character set name.
      *
-     * @param uidsets the list of UID set
-     * @param term the search expression tree
+     * @param msgsets the set of MessageNumberSet
+     * @param term the search term
+     * @param capa the capability instance to check if it has literal
+     * @throws ImapAsyncClientException when both msgsets and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
      */
-    public UidSearchCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final SearchTerm term) {
-        this(UIDSet.toString(uidsets), term);
+    public UidSearchCommand(@Nullable final MessageNumberSet[] msgsets, @Nullable final SearchTerm term, @Nullable final Capability capa)
+            throws ImapAsyncClientException, SearchException, IOException {
+        super(true, msgsets, term, capa);
     }
 
     /**
-     * Initializes a @{code UidSearchCommand} with the msg UID string directly.
+     * Initializes this object with the string form of message sequence, SearchTerm.
      *
-     * @param uids the messages UID string
-     * @param term the search expression tree
+     * @param msgNumbers the string form message numbers in sequence-set syntax
+     * @param term the search term
+     * @param capa the capability instance to find if it has literal
+     * @throws ImapAsyncClientException when both msgNumber and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
      */
-    private UidSearchCommand(@Nonnull final String uids, @Nonnull final SearchTerm term) {
-        this.uids = uids;
-        this.term = term;
+    public UidSearchCommand(@Nullable final String msgNumbers, @Nullable final SearchTerm term, @Nullable final Capability capa)
+            throws ImapAsyncClientException, SearchException, IOException {
+        super(true, msgNumbers, term, capa);
+    }
+
+    /**
+     * Initializes this object with the string form of message sequence, character set name, and Argument that expresses the search term.
+     *
+     * @param msgNumbers the string form message numbers in sequence-set syntax
+     * @param charset the character set
+     * @param args the search term in argument format
+     * @param capa the capability instance to find if it has literal
+     * @throws ImapAsyncClientException when both msgNumber and searchString are null
+     * @throws IOException when parsing error for generate sequence
+     * @throws SearchException when search term cannot be found
+     */
+    public UidSearchCommand(@Nullable final String msgNumbers, @Nullable final String charset, @Nonnull final Argument args,
+            @Nullable final Capability capa) throws ImapAsyncClientException, SearchException, IOException {
+        super(true, msgNumbers, charset, args, capa);
     }
 
     @Override
-    public void cleanup() {
-        this.uids = null;
-        this.term = null;
-    }
-
-    @Override
-    public String getCommandLine() throws SearchException, IOException {
-        // maintain same semantic with IMAPProtocol, but we do not retry when fail in various of charsets. we only use UTF_8
-        final String charset = SearchSequence.isAscii(term) ? null : StandardCharsets.UTF_8.name();
-
-        // convert from search expression tree to String
-        final SearchSequence searchSeq = new SearchSequence();
-        final Argument args = new Argument();
-        args.append(searchSeq.generateSequence(term, charset == null ? null : MimeUtility.javaCharset(charset)));
-        args.writeAtom(uids);
-
-        final String searchStr = args.toString();
-
-        final StringBuilder sb = new StringBuilder(searchStr.length() + ImapClientConstants.PAD_LEN).append(UID_SEARCH_SPACE);
-
-        if (charset != null) {
-            sb.append(CHARSET).append(charset).append(ImapClientConstants.SPACE);
-        }
-        sb.append(searchStr).append(ImapClientConstants.CRLF);
-        return sb.toString();
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UID_SEARCH;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UidStoreFlagsCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UidStoreFlagsCommand.java
@@ -3,67 +3,53 @@ package com.yahoo.imapnio.async.request;
 import javax.annotation.Nonnull;
 import javax.mail.Flags;
 
-import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 
 /**
  * This class defines IMAP UID store command request from client.
  */
-public class UidStoreFlagsCommand extends ImapRequestAdapter {
-
-    /** UID STORE and space. */
-    private static final String UID_STORE_SPACE = "UID STORE ";
-
-    /** Literal for FLAGS. */
-    private static final String FLAGS_SP = "FLAGS ";
-
-    /** A collection of messages id specified based on RFC3501 syntax. */
-    private String uids;
-
-    /** Messages flags. */
-    private Flags flags;
-
-    /** Flag to indicate whether to add or remove existing. */
-    private final boolean isSet;
+public class UidStoreFlagsCommand extends AbstractStoreFlagsCommand {
 
     /**
-     * Initializes a @{code UidStoreFlagsCommand} with the UIDSet array.
+     * Initializes a @{code UidStoreFlagsCommand} with the MessageNumberSet array, Flags and action. Requests server to return the new value.
      *
-     * @param uidsets the set of uid set
+     * @param msgsets the set of message set
      * @param flags the flags to be stored
-     * @param set true if the specified flags are to be set, false to clear them
+     * @param action whether to replace, add or remove the flags
      */
-    public UidStoreFlagsCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final Flags flags, final boolean set) {
-        this(UIDSet.toString(uidsets), flags, set);
+    public UidStoreFlagsCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final Flags flags, @Nonnull final FlagsAction action) {
+        super(true, msgsets, flags, action, false);
     }
 
     /**
-     * Initializes a @{code UidStoreFlagsCommand} with the uid string directly.
+     * Initializes a @{code UidStoreFlagsCommand} with the MessageNumberSet array, Flags, action, flag whether to request server to return the new
+     * value.
      *
-     * @param uids the messages set
+     * @param msgsets the set of message set
      * @param flags the flags to be stored
-     * @param set true if the specified flags are to be set, false to clear them
+     * @param action whether to replace, add or remove the flags
+     * @param silent true if asking server to respond silently; false if requesting server to return the new values
      */
-    public UidStoreFlagsCommand(@Nonnull final String uids, @Nonnull final Flags flags, final boolean set) {
-        this.uids = uids;
-        this.flags = flags;
-        this.isSet = set;
+    public UidStoreFlagsCommand(@Nonnull final MessageNumberSet[] msgsets, @Nonnull final Flags flags, @Nonnull final FlagsAction action,
+            final boolean silent) {
+        super(true, msgsets, flags, action, silent);
+    }
+
+    /**
+     * Initializes a @{code UidStoreFlagsCommand} with string form message numbers, Flags, action, flag whether to request server to return the new
+     * value.
+     *
+     * @param uids the string representing UID based on RFC3501
+     * @param flags the flags to be stored
+     * @param action whether to replace, add or remove the flags
+     * @param silent true if asking server to respond silently; false if requesting server to return the new values
+     */
+    public UidStoreFlagsCommand(@Nonnull final String uids, @Nonnull final Flags flags, @Nonnull final FlagsAction action, final boolean silent) {
+        super(true, uids, flags, action, silent);
     }
 
     @Override
-    public void cleanup() {
-        this.uids = null;
-        this.flags = null;
-    }
-
-    @Override
-    public String getCommandLine() {
-        // Ex:STORE 2:4 +FLAGS (\Deleted)
-        final ImapArgumentFormatter argWriter = new ImapArgumentFormatter();
-        final StringBuilder sb = new StringBuilder(UID_STORE_SPACE).append(uids).append(ImapClientConstants.SPACE);
-
-        sb.append(isSet ? ImapClientConstants.PLUS : ImapClientConstants.MINUS).append(FLAGS_SP).append(argWriter.buildFlagString(flags))
-                .append(ImapClientConstants.CRLF);
-
-        return sb.toString();
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UID_STORE_FLAGS;
     }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UnselectCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UnselectCommand.java
@@ -14,4 +14,9 @@ public class UnselectCommand extends AbstractNoArgsCommand {
     public UnselectCommand() {
         super(UNSELECT);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UNSELECT;
+    }
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/request/UnsubscribeFolderCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/UnsubscribeFolderCommand.java
@@ -18,4 +18,9 @@ public class UnsubscribeFolderCommand extends AbstractFolderActionCommand {
     public UnsubscribeFolderCommand(@Nonnull final String folderName) {
         super(UNSUBSCRIBE, folderName);
     }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.UNSUBSCRIBE;
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/data/MessageNumberSetTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/MessageNumberSetTest.java
@@ -1,0 +1,226 @@
+package com.yahoo.imapnio.async.data;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.yahoo.imapnio.async.data.MessageNumberSet.LastMessage;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException.FailureType;
+
+/**
+ * Unit test for {@code MessageNumberSet}.
+ */
+public class MessageNumberSetTest {
+
+    /**
+     * Tests constructor and converting it to string.
+     */
+    @Test
+    public void testConstructorWithStartEnd() {
+        final MessageNumberSet msgSet = new MessageNumberSet(1, 100);
+        Assert.assertNotNull(msgSet, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(new MessageNumberSet[] { msgSet }), "1:100", "Result mismatched.");
+    }
+
+    /**
+     * Tests constructor where starts with specific message and ends with last message and converting it to string.
+     */
+    @Test
+    public void testConstructorWithStartEndWithLast() {
+        final MessageNumberSet msgSet = new MessageNumberSet(1, LastMessage.LAST_MESSAGE);
+        Assert.assertNotNull(msgSet, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(new MessageNumberSet[] { msgSet }), "1:*", "Result mismatched.");
+    }
+
+    /**
+     * Tests constructor where it has only one message and converting it to string.
+     */
+    @Test
+    public void testConstructorWithStartAndEndSame() {
+        final MessageNumberSet msgSet = new MessageNumberSet(1, 1);
+        Assert.assertNotNull(msgSet, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(new MessageNumberSet[] { msgSet }), "1", "Result mismatched.");
+    }
+
+    /**
+     * Tests constructor and converting it to string.
+     *
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testConstructorLastMessageOnlyTrue() throws ImapAsyncClientException {
+        final MessageNumberSet msgSet = new MessageNumberSet(LastMessage.LAST_MESSAGE);
+        Assert.assertNotNull(msgSet, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(new MessageNumberSet[] { msgSet }), "*", "Result mismatched.");
+    }
+
+    /**
+     * Tests createMessageNumberSets(int[]) method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testCreateMessageNumberSetsFromIntArray() throws ImapAsyncClientException {
+        final int[] msgs = { 1, 2, 3, 4, 5, 7 };
+
+        final MessageNumberSet[] sets = MessageNumberSet.createMessageNumberSets(msgs);
+        Assert.assertNotNull(sets, "Should not be null");
+        Assert.assertEquals(sets.length, 2, "lenth mismatched.");
+        Assert.assertEquals(MessageNumberSet.buildString(sets), "1:5,7", "Expect result mismatched.");
+    }
+
+    /**
+     * Tests createMessageNumberSets(int[]) method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testCreateMessageNumberSetsFromLongArray() throws ImapAsyncClientException {
+        final long[] msgs = { 1, 2, 3, 4, 5, 7, 1 };
+
+        final MessageNumberSet[] sets = MessageNumberSet.createMessageNumberSets(msgs);
+        Assert.assertNotNull(sets, "Should not be null");
+        Assert.assertEquals(sets.length, 3, "lenth mismatched.");
+        Assert.assertEquals(MessageNumberSet.buildString(sets), "1:5,7,1", "Expect result mismatched.");
+    }
+
+    /**
+     * Tests createMessageNumberSets(int[]) method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testRemovePointDuplicates() throws ImapAsyncClientException {
+        final long[] msgs = { 1, 1, 1, 1, 1, 1, 1 };
+
+        final MessageNumberSet[] sets = MessageNumberSet.createMessageNumberSets(msgs);
+        Assert.assertNotNull(sets, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(sets), "1", "Expect result mismatched.");
+    }
+
+    /**
+     * Tests createMessageNumberSets(int[]) method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testRemoveRangesAndPointsDuplicates() throws ImapAsyncClientException {
+
+        final MessageNumberSet[] sets = { new MessageNumberSet(1, 5), new MessageNumberSet(5, 1), new MessageNumberSet(1, LastMessage.LAST_MESSAGE),
+                new MessageNumberSet(1, 5), new MessageNumberSet(2, 2), new MessageNumberSet(LastMessage.LAST_MESSAGE), new MessageNumberSet(2, 2) };
+        Assert.assertNotNull(sets, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(sets), "1:5,1:*,2,*", "Expect result mismatched.");
+    }
+
+    /**
+     * Tests buildString method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testBuildString() throws ImapAsyncClientException {
+        final MessageNumberSet[] sets = new MessageNumberSet[3];
+
+        sets[0] = new MessageNumberSet(LastMessage.LAST_MESSAGE);
+        sets[1] = new MessageNumberSet(1, 5);
+        sets[2] = new MessageNumberSet(3, 3);
+        Assert.assertNotNull(sets, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(sets), "*,1:5,3", "Result mismatched.");
+    }
+
+    /**
+     * Tests constructor and converting it to string.
+     */
+    @Test
+    public void testBuildStringWithNullMessageNumberSets() {
+        Assert.assertNull(MessageNumberSet.buildString(null), "Result mismatched.");
+    }
+
+    /**
+     * Tests constructor and converting it to string.
+     */
+    @Test
+    public void testBuildStringWith0LengthMessageNumberSets() {
+        Assert.assertNull(MessageNumberSet.buildString(new MessageNumberSet[0]), "Result mismatched.");
+    }
+
+    /**
+     * Tests constructor and converting it to string.
+     *
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testConstructorLastMessageOnlyFalse() throws ImapAsyncClientException {
+        ImapAsyncClientException actual = null;
+        try {
+            new MessageNumberSet(null);
+        } catch (final ImapAsyncClientException e) {
+            actual = e;
+        }
+        Assert.assertNotNull(actual, "Exception should be thrown");
+        Assert.assertEquals(actual.getFaiureType(), FailureType.INVALID_INPUT, "Result mismatched.");
+    }
+
+    /**
+     * Tests equals with same type, start, and ending point.
+     */
+    @Test
+    public void testEqualsTrue() {
+        final MessageNumberSet msgSet1 = new MessageNumberSet(1, 100);
+        final MessageNumberSet msgSet2 = new MessageNumberSet(1, 100);
+        Assert.assertNotNull(msgSet1, "Should not be null");
+        Assert.assertTrue(msgSet1.equals(msgSet2), "Result mismatched.");
+    }
+
+    /**
+     * Tests equals with different class.
+     */
+    @Test
+    public void testEqualsDiffClass() {
+        final MessageNumberSet msgSet = new MessageNumberSet(1, 100);
+        Assert.assertNotNull(msgSet, "Should not be null");
+        final String u = new String("hello");
+        Assert.assertFalse(msgSet.equals(u), "Result mismatched.");
+    }
+
+    /**
+     * Tests equals with different sequence type.
+     */
+    @Test
+    public void testEqualsDiffSeqType() {
+        final MessageNumberSet msgSet1 = new MessageNumberSet(1, 100);
+        final MessageNumberSet msgSet2 = new MessageNumberSet(1, LastMessage.LAST_MESSAGE);
+        Assert.assertFalse(msgSet1.equals(msgSet2), "Result mismatched.");
+    }
+
+    /**
+     * Tests equals with different ending point.
+     */
+    @Test
+    public void testEqualsDiffEnd() {
+        final MessageNumberSet msgSet1 = new MessageNumberSet(1, 100);
+        final MessageNumberSet msgSet2 = new MessageNumberSet(1, 101);
+        Assert.assertFalse(msgSet1.equals(msgSet2), "Result mismatched.");
+    }
+
+    /**
+     * Tests equals with different starting point.
+     */
+    @Test
+    public void testEqualsDiffStart() {
+        final MessageNumberSet msgSet1 = new MessageNumberSet(1, 100);
+        final MessageNumberSet msgSet2 = new MessageNumberSet(2, 100);
+        Assert.assertFalse(msgSet1.equals(msgSet2), "Result mismatched.");
+    }
+
+    /**
+     * Tests SequenceType enum.
+     */
+    @Test
+    public void testCommandTypeEnum() {
+        final LastMessage[] enumList = LastMessage.values();
+        Assert.assertEquals(enumList.length, 1, "The enum count mismatched.");
+        final LastMessage value = LastMessage.valueOf("LAST_MESSAGE");
+        Assert.assertSame(value, LastMessage.LAST_MESSAGE, "Enum does not match.");
+    }
+}

--- a/core/src/test/java/com/yahoo/imapnio/async/data/SearchResultTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/SearchResultTest.java
@@ -1,0 +1,36 @@
+package com.yahoo.imapnio.async.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@code SearchResult}.
+ */
+public class SearchResultTest {
+
+    /**
+     * Tests SearchResult constructor and getters.
+     */
+    @Test
+    public void testSearchResult() {
+        final List<Long> ll = new ArrayList<>();
+        ll.add(Long.MAX_VALUE - 1);
+        final SearchResult infos = new SearchResult(ll);
+        final List<Long> result = infos.getMessageNumbers();
+        Assert.assertEquals(result.size(), 1, "Result mismatched.");
+        Assert.assertEquals(result.get(0), Long.valueOf(Long.MAX_VALUE - 1), "Result mismatched.");
+    }
+
+    /**
+     * Tests SearchResult constructor and getters when passing null list.
+     */
+    @Test
+    public void testSearchResultNullList() {
+        final SearchResult infos = new SearchResult(null);
+        final List<Long> result = infos.getMessageNumbers();
+        Assert.assertNull(result, "Result mismatched.");
+    }
+}

--- a/core/src/test/java/com/yahoo/imapnio/async/internal/CompressCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/internal/CompressCommandTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.internal.CompressCommand;
+import com.yahoo.imapnio.async.request.ImapCommandType;
 import com.yahoo.imapnio.async.request.ImapRequest;
 
 /**
@@ -63,4 +63,12 @@ public class CompressCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new CompressCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.COMPRESS);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImplTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImplTest.java
@@ -115,7 +115,7 @@ public class ImapAsyncSessionImplTest {
         // execute Authenticate plain command
         {
             final Map<String, List<String>> capas = new HashMap<String, List<String>>();
-            final ImapRequest<String> cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
+            final ImapRequest cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
             final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
             Mockito.verify(authWritePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
             Mockito.verify(channel, Mockito.times(1)).writeAndFlush(Mockito.anyString(), Mockito.isA(ChannelPromise.class));
@@ -156,7 +156,7 @@ public class ImapAsyncSessionImplTest {
             Mockito.when(logger.isDebugEnabled()).thenReturn(true);
             aSession.setDebugMode(DebugMode.DEBUG_ON);
             // execute capa
-            final ImapRequest<String> cmd = new CapaCommand();
+            final ImapRequest cmd = new CapaCommand();
             final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
 
             Mockito.verify(capaWritePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
@@ -263,7 +263,7 @@ public class ImapAsyncSessionImplTest {
         // execute Authenticate plain command
         {
             final Map<String, List<String>> capas = new HashMap<String, List<String>>();
-            final ImapRequest<String> cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
+            final ImapRequest cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
             final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
             Mockito.verify(authWritePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
             Mockito.verify(channel, Mockito.times(1)).writeAndFlush(Mockito.anyString(), Mockito.isA(ChannelPromise.class));
@@ -385,7 +385,7 @@ public class ImapAsyncSessionImplTest {
         // execute Authenticate plain command
         {
             final Map<String, List<String>> capas = new HashMap<String, List<String>>();
-            final ImapRequest<String> cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
+            final ImapRequest cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
             final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
             Mockito.verify(authWritePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
             Mockito.verify(channel, Mockito.times(1)).writeAndFlush(Mockito.anyString(), Mockito.isA(ChannelPromise.class));
@@ -507,7 +507,7 @@ public class ImapAsyncSessionImplTest {
         // execute Authenticate plain command
         {
             final Map<String, List<String>> capas = new HashMap<String, List<String>>();
-            final ImapRequest<String> cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
+            final ImapRequest cmd = new AuthPlainCommand("orange", "juicy", new Capability(capas));
             final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
             Mockito.verify(authWritePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
             Mockito.verify(channel, Mockito.times(1)).writeAndFlush(Mockito.anyString(), Mockito.isA(ChannelPromise.class));
@@ -622,7 +622,7 @@ public class ImapAsyncSessionImplTest {
         final ImapAsyncSessionImpl aSession = new ImapAsyncSessionImpl(channel, logger, DebugMode.DEBUG_ON, SESSION_ID, pipeline);
 
         // execute
-        final ImapRequest<String> cmd = new CapaCommand();
+        final ImapRequest cmd = new CapaCommand();
         final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
 
         final IdleStateEvent idleEvent = null;
@@ -708,7 +708,7 @@ public class ImapAsyncSessionImplTest {
         final ImapAsyncSessionImpl aSession = new ImapAsyncSessionImpl(channel, logger, DebugMode.DEBUG_ON, SESSION_ID, pipeline);
 
         // execute
-        final ImapRequest<String> cmd = new CapaCommand();
+        final ImapRequest cmd = new CapaCommand();
         final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
 
         Mockito.verify(writePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
@@ -806,7 +806,7 @@ public class ImapAsyncSessionImplTest {
         final ImapAsyncSessionImpl aSession = new ImapAsyncSessionImpl(channel, logger, DebugMode.DEBUG_ON, SESSION_ID, pipeline);
 
         // execute
-        final ImapRequest<String> cmd = new CapaCommand();
+        final ImapRequest cmd = new CapaCommand();
         final ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
 
         Mockito.verify(writePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
@@ -879,7 +879,7 @@ public class ImapAsyncSessionImplTest {
 
         // execute
         final ConcurrentLinkedQueue<IMAPResponse> serverResponesQ = new ConcurrentLinkedQueue<IMAPResponse>();
-        final ImapRequest<String> cmd = new IdleCommand(serverResponesQ);
+        final ImapRequest cmd = new IdleCommand(serverResponesQ);
         ImapFuture<ImapAsyncResponse> future = aSession.execute(cmd);
 
         Mockito.verify(writePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
@@ -969,7 +969,7 @@ public class ImapAsyncSessionImplTest {
         final Logger logger = Mockito.mock(Logger.class);
         Mockito.when(logger.isDebugEnabled()).thenReturn(true);
         final ImapAsyncSessionImpl aSession = new ImapAsyncSessionImpl(channel, logger, DebugMode.DEBUG_ON, SESSION_ID, pipeline);
-        final ImapRequest<String> cmd = new CapaCommand();
+        final ImapRequest cmd = new CapaCommand();
         aSession.execute(cmd);
 
         Mockito.verify(writePromise, Mockito.times(1)).addListener(Mockito.any(ImapAsyncSessionImpl.class));
@@ -1014,7 +1014,7 @@ public class ImapAsyncSessionImplTest {
 
         // constructor, class level debug is off, but session level is on
         final ImapAsyncSessionImpl aSession = new ImapAsyncSessionImpl(channel, logger, DebugMode.DEBUG_ON, SESSION_ID, pipeline);
-        final ImapRequest<String> cmd = new CapaCommand();
+        final ImapRequest cmd = new CapaCommand();
         ImapAsyncClientException ex = null;
         try {
             // execute again, queue is not empty
@@ -1058,7 +1058,7 @@ public class ImapAsyncSessionImplTest {
         final Logger logger = Mockito.mock(Logger.class);
         Mockito.when(logger.isDebugEnabled()).thenReturn(false);
         final ImapAsyncSessionImpl aSession = new ImapAsyncSessionImpl(null, logger, DebugMode.DEBUG_ON, SESSION_ID, pipeline);
-        final ImapRequest<String> cmd = new CapaCommand();
+        final ImapRequest cmd = new CapaCommand();
         ImapAsyncClientException ex = null;
         try {
             // execute again, queue is not empty

--- a/core/src/test/java/com/yahoo/imapnio/async/request/CapaCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/CapaCommandTest.java
@@ -107,4 +107,13 @@ public class CapaCommandTest {
         Assert.assertEquals(ex.getFaiureType(), ImapAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
                 "Expected result mismatched.");
     }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new CapaCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.CAPABILITY);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/CheckCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/CheckCommandTest.java
@@ -63,4 +63,12 @@ public class CheckCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new CheckCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.CHECK);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/CloseCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/CloseCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.CloseCommand;
-import com.yahoo.imapnio.async.request.ImapRequest;
 
 /**
  * Unit test for {@code CloseCommand}.
@@ -63,4 +61,12 @@ public class CloseCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new CloseCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.CLOSE);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/CreateFolderCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/CreateFolderCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.CreateFolderCommand;
-import com.yahoo.imapnio.async.request.ImapRequest;
 
 /**
  * Unit test for {@code CreateFolderCommand}.
@@ -92,5 +90,14 @@ public class CreateFolderCommandTest {
         final String folderName = "测试";
         final ImapRequest cmd = new CreateFolderCommand(folderName);
         Assert.assertEquals(cmd.getCommandLine(), CREATE + "&bUuL1Q-\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new CreateFolderCommand("folderToBeCreated");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.CREATE_FOLDER);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/DeleteFolderCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/DeleteFolderCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.DeleteFolderCommand;
-import com.yahoo.imapnio.async.request.ImapRequest;
 
 /**
  * Unit test for {@code DeleteFolderCommand}.
@@ -92,5 +90,14 @@ public class DeleteFolderCommandTest {
         final String folderName = "测试";
         final ImapRequest cmd = new DeleteFolderCommand(folderName);
         Assert.assertEquals(cmd.getCommandLine(), DELETE + "&bUuL1Q-\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new DeleteFolderCommand("folderToBeDeleted");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.DELETE_FOLDER);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/ExamineFolderCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/ExamineFolderCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ExamineFolderCommand;
-import com.yahoo.imapnio.async.request.ImapRequest;
 
 /**
  * Unit test for {@code ExamineFolderCommand}.
@@ -92,5 +90,14 @@ public class ExamineFolderCommandTest {
         final String folderName = "测试";
         final ImapRequest cmd = new ExamineFolderCommand(folderName);
         Assert.assertEquals(cmd.getCommandLine(), EXAMINE + "&bUuL1Q-\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new ExamineFolderCommand("testFolder");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.EXAMINE_FOLDER);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/ExpungeCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/ExpungeCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ExpungeCommand;
-import com.yahoo.imapnio.async.request.ImapRequest;
 
 /**
  * Unit test for {@code ExpungeCommand}.
@@ -63,4 +61,12 @@ public class ExpungeCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new ExpungeCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.EXPUNGE);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/IdCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/IdCommandTest.java
@@ -135,4 +135,13 @@ public class IdCommandTest {
         Assert.assertEquals(ex.getFaiureType(), ImapAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
                 "Expected result mismatched.");
     }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new IdCommand(null);
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.ID);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/ImapArgumentFormatterByteBufTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/ImapArgumentFormatterByteBufTest.java
@@ -1,0 +1,192 @@
+package com.yahoo.imapnio.async.request;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Unit test for {@code ImapArgumentFormatter}.
+ */
+public class ImapArgumentFormatterByteBufTest {
+
+    /**
+     * Tests when source string has space.
+     *
+     * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testSourceNoQuoteNeeded() throws IOException, ImapAsyncClientException {
+        final ImapArgumentFormatter writer = new ImapArgumentFormatter();
+        final String src = "Bulk";
+        final ByteBuf out = Unpooled.buffer();
+        final boolean doQuote = false;
+        writer.formatArgument(src, out, doQuote);
+        Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "Bulk", "Encoded result mismatched.");
+    }
+
+    /**
+     * Tests when source string has CR or LF or \0 or special chars(>127).
+     *
+     * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testSourceAsItIs() throws IOException, ImapAsyncClientException {
+        // \r
+        {
+            final ImapArgumentFormatter writer = new ImapArgumentFormatter();
+            final byte[] bytes = { 'a', '\r' };
+            final String src = new String(bytes);
+            final ByteBuf out = Unpooled.buffer();
+            final boolean doQuote = false;
+            writer.formatArgument(src, out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "a\r", "Encoded result mismatched.");
+        }
+        // \n
+        {
+            final ImapArgumentFormatter writer = new ImapArgumentFormatter();
+            final byte[] bytes = { 'a', '\n' };
+            final String src = new String(bytes, StandardCharsets.US_ASCII);
+            final ByteBuf out = Unpooled.buffer();
+            final boolean doQuote = false;
+            writer.formatArgument(src, out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "a\n", "Encoded result mismatched.");
+        }
+        // \0
+        {
+            final ImapArgumentFormatter writer = new ImapArgumentFormatter();
+            final byte[] bytes = { 'a', '\0' };
+            final String src = new String(bytes, StandardCharsets.US_ASCII);
+            final ByteBuf out = Unpooled.buffer();
+            final boolean doQuote = false;
+            writer.formatArgument(src, out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "a\0", "Encoded result mismatched.");
+        }
+        // Char ascii code > 127
+        {
+            final ImapArgumentFormatter writer = new ImapArgumentFormatter();
+            final char c = '\u03A9'; // Omega character
+            final String src = Character.toString(c);
+            final ByteBuf out = Unpooled.buffer();
+            final boolean doQuote = false;
+            ImapAsyncClientException actual = null;
+            try {
+                writer.formatArgument(src, out, doQuote);
+            } catch (final ImapAsyncClientException e) {
+                actual = e;
+            }
+            Assert.assertNotNull(actual, "Should throw exception");
+            Assert.assertEquals(actual.getFaiureType(), ImapAsyncClientException.FailureType.INVALID_INPUT, "Should throw exception");
+        }
+    }
+
+    /**
+     * Tests when source string has character that needs to be double quoted.
+     *
+     * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testSourceNeedsQuote() throws IOException, ImapAsyncClientException {
+        // if (b == '*' || b == '%' || b == '(' || b == ')' || b == '{' || b == '"' || b == '\\' || ((b & 0xff) <= ' ')) {
+        final ImapArgumentFormatter writer = new ImapArgumentFormatter();
+        final boolean doQuote = false;
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("B*", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"B*\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("B%", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"B%\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("B(", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"B(\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("B)", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"B)\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("B{", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"B{\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("B\"", out, doQuote); // excpects double quote and escape
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"B\\\"\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("B\\", out, doQuote); // excpects double quote and escape
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"B\\\\\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            final char c = '\u0011'; // spcial char less than space ascii code
+            final String src = Character.toString(c);
+            writer.formatArgument(src, out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            final String src = ""; // empty string
+            writer.formatArgument(src, out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"\"", "Encoded result mismatched.");
+        }
+    }
+
+    /**
+     * Tests when source has NIL literal.
+     *
+     * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
+     */
+    @Test
+    public void testHasLiteralNIL() throws IOException, ImapAsyncClientException {
+        final ImapArgumentFormatter writer = new ImapArgumentFormatter();
+        final boolean doQuote = false;
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("NIL", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"NIL\"", "Encoded result mismatched.");
+        }
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("nil", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "\"nil\"", "Encoded result mismatched.");
+        }
+        // test false positive: qualify first 2 letters
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("NIi", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "NIi", "Encoded result mismatched.");
+        }
+        // test false positive: qualify first letter
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("NxL", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "NxL", "Encoded result mismatched.");
+        }
+        // test false positive: 3 chars
+        {
+            final ByteBuf out = Unpooled.buffer();
+            writer.formatArgument("LIN", out, doQuote);
+            Assert.assertEquals(out.toString(StandardCharsets.US_ASCII), "LIN", "Encoded result mismatched.");
+        }
+    }
+
+}

--- a/core/src/test/java/com/yahoo/imapnio/async/request/ImapArgumentFormatterTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/ImapArgumentFormatterTest.java
@@ -8,7 +8,7 @@ import javax.mail.Flags;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.yahoo.imapnio.async.request.ImapArgumentFormatter;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
 
 /**
  * Unit test for {@code ImapArgumentFormatter}.
@@ -19,9 +19,10 @@ public class ImapArgumentFormatterTest {
      * Tests when source string has space.
      *
      * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
      */
     @Test
-    public void testSourceNoQuoteNeeded() throws IOException {
+    public void testSourceNoQuoteNeeded() throws IOException, ImapAsyncClientException {
         final ImapArgumentFormatter writer = new ImapArgumentFormatter();
         final String src = "Bulk";
         final StringBuilder out = new StringBuilder();
@@ -34,9 +35,10 @@ public class ImapArgumentFormatterTest {
      * Tests when source string has CR or LF or \0 or special chars(>127).
      *
      * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
      */
     @Test
-    public void testSourceAsItIs() throws IOException {
+    public void testSourceAsItIs() throws IOException, ImapAsyncClientException {
         // \r
         {
             final ImapArgumentFormatter writer = new ImapArgumentFormatter();
@@ -74,8 +76,14 @@ public class ImapArgumentFormatterTest {
             final String src = Character.toString(c);
             final StringBuilder out = new StringBuilder();
             final boolean doQuote = false;
-            writer.formatArgument(src, out, doQuote);
-            Assert.assertEquals(out.toString(), "Ω", "Encoded result mismatched.");
+            ImapAsyncClientException actual = null;
+            try {
+                writer.formatArgument(src, out, doQuote);
+            } catch (final ImapAsyncClientException e) {
+                actual = e;
+            }
+            Assert.assertNotNull(actual, "Should throw exception");
+            Assert.assertEquals(actual.getFaiureType(), ImapAsyncClientException.FailureType.INVALID_INPUT, "Should throw exception");
         }
     }
 
@@ -83,9 +91,10 @@ public class ImapArgumentFormatterTest {
      * Tests when source string has character that needs to be double quoted.
      *
      * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
      */
     @Test
-    public void testSourceNeedsQuote() throws IOException {
+    public void testSourceNeedsQuote() throws IOException, ImapAsyncClientException {
         // if (b == '*' || b == '%' || b == '(' || b == ')' || b == '{' || b == '"' || b == '\\' || ((b & 0xff) <= ' ')) {
         final ImapArgumentFormatter writer = new ImapArgumentFormatter();
         final boolean doQuote = false;
@@ -143,9 +152,10 @@ public class ImapArgumentFormatterTest {
      * Tests when source has NIL literal.
      *
      * @throws IOException will not throw
+     * @throws ImapAsyncClientException will not throw
      */
     @Test
-    public void testHasLiteralNIL() throws IOException {
+    public void testHasLiteralNIL() throws IOException, ImapAsyncClientException {
         final ImapArgumentFormatter writer = new ImapArgumentFormatter();
         final boolean doQuote = false;
         {

--- a/core/src/test/java/com/yahoo/imapnio/async/request/LSubCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/LSubCommandTest.java
@@ -127,4 +127,13 @@ public class LSubCommandTest {
         Assert.assertEquals(ex.getFaiureType(), ImapAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
                 "Expected result mismatched.");
     }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new LSubCommand("", "*test*");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.LSUB);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/ListCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/ListCommandTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 import com.sun.mail.imap.protocol.IMAPResponse;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
 
-
 /**
  * Unit test for {@code ListCommand}.
  */
@@ -127,5 +126,14 @@ public class ListCommandTest {
         Assert.assertNotNull(ex, "Expect exception to be thrown.");
         Assert.assertEquals(ex.getFaiureType(), ImapAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
                 "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new ListCommand("", "*test*");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.LIST);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/LoginCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/LoginCommandTest.java
@@ -67,6 +67,32 @@ public class LoginCommandTest {
     }
 
     /**
+     * Tests getCommandLine method with emptry strings in both user and token.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testGetCommandLineEmptyString()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final String username = "";
+        final String pwd = "";
+        final ImapRequest cmd = new LoginCommand(username, pwd);
+        Assert.assertEquals(cmd.getCommandLine(), "LOGIN \"\" \"\"\r\n", "Expected result mismatched.");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive(), "isCommandLineDataSensitive() result mismatched.");
+        Assert.assertEquals(cmd.getDebugData(), "LOGIN FOR USER:", "Log line mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
      * Tests getStreamingResponsesQueue method.
      */
     @Test
@@ -108,5 +134,14 @@ public class LoginCommandTest {
         Assert.assertNotNull(ex, "Expect exception to be thrown.");
         Assert.assertEquals(ex.getFaiureType(), ImapAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
                 "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new LoginCommand("neighbor", "hood");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.LOGIN);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/LogoutCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/LogoutCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.LogoutCommand;
 
 /**
  * Unit test for {@code LogoutCommand}.
@@ -63,4 +61,12 @@ public class LogoutCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new LogoutCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.LOGOUT);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/MoveMessageCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/MoveMessageCommandTest.java
@@ -13,9 +13,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.sun.mail.imap.protocol.MessageSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.MoveMessageCommand;
 
 /**
  * Unit test for {@code MoveMessageCommand}.
@@ -69,7 +68,7 @@ public class MoveMessageCommandTest {
     }
 
     /**
-     * Tests getCommandLine method.
+     * Tests constructor with start and end message sequence and getCommandLine method.
      *
      * @throws ImapAsyncClientException will not throw
      * @throws SearchException will not throw
@@ -78,10 +77,34 @@ public class MoveMessageCommandTest {
      * @throws IllegalArgumentException will not throw
      */
     @Test
-    public void testMessageUidGetCommandLine()
+    public void testConstructorStartEndGetCommandLine()
             throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
         final String folderName = "folderABC";
         final ImapRequest cmd = new MoveMessageCommand(37850, 37852, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "MOVE 37850:37852 folderABC\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor with @{MessageNumberSet} and getCommandLine method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testConstructorMessageNumberSetGetCommandLine()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final String folderName = "folderABC";
+        final MessageNumberSet[] mset = MessageNumberSet.createMessageNumberSets(new long[] { 37850L, 37851L, 37852L });
+        final ImapRequest cmd = new MoveMessageCommand(mset, folderName);
         Assert.assertEquals(cmd.getCommandLine(), "MOVE 37850:37852 folderABC\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
@@ -118,5 +141,14 @@ public class MoveMessageCommandTest {
         final String folderName = "测试";
         final ImapRequest cmd = new MoveMessageCommand(37850, 37852, folderName);
         Assert.assertEquals(cmd.getCommandLine(), "MOVE 37850:37852 &bUuL1Q-\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new MoveMessageCommand(37850, 37852, "targetFolder");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.MOVE_MESSAGE);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/NoopCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/NoopCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.NoopCommand;
 
 /**
  * Unit test for {@code NoopCommand}.
@@ -63,4 +61,12 @@ public class NoopCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new NoopCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.NOOP);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/RenameFolderCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/RenameFolderCommandTest.java
@@ -13,9 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.RenameFolderCommand;
-
 
 /**
  * Unit test for {@code RenameFolderCommand}.
@@ -96,5 +93,14 @@ public class RenameFolderCommandTest {
         final String newName = "folderDEF";
         final ImapRequest cmd = new RenameFolderCommand(oldName, newName);
         Assert.assertEquals(cmd.getCommandLine(), RENAME + "&bUuL1Q- folderDEF\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new RenameFolderCommand("oldName", "newName");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.RENAME_FOLDER);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/SearchCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/SearchCommandTest.java
@@ -1,9 +1,16 @@
 package com.yahoo.imapnio.async.request;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.mail.Flags;
@@ -15,10 +22,15 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.sun.mail.imap.protocol.MessageSet;
+import com.sun.mail.iap.Argument;
+import com.sun.mail.iap.Literal;
+import com.yahoo.imapnio.async.data.Capability;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet.LastMessage;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.SearchCommand;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException.FailureType;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Unit test for {@code SearchCommand}.
@@ -47,7 +59,7 @@ public class SearchCommandTest {
     }
 
     /**
-     * Tests getCommandLine method using Message sequences.
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
      *
      * @throws IOException will not throw
      * @throws IllegalAccessException will not throw
@@ -56,23 +68,223 @@ public class SearchCommandTest {
      * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithMessageSequence()
+    public void testGetCommandLineNoneNullMessageSeqSetsNonNullSearchTerm()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
-
-        final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
+        final int[] msgNos = { 1, 2, 3 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgNos);
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
         final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
-        final ImapRequest cmd = new SearchCommand(msgsets, messageFlagTerms);
-        Assert.assertEquals(cmd.getCommandLine(), "SEARCH DELETED SEEN 1:3\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new SearchCommand(msgsets, messageFlagTerms, null);
+        Assert.assertEquals(cmd.getCommandLine(), "SEARCH 1:3 DELETED SEEN\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
         for (final Field field : fieldsToCheck) {
             Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
         }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNoneMessageSeqAndArgument()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Argument args = new Argument();
+
+        // Chinese input: \u5929\u5c31\u7070\u7070\u7684
+        final String input = "\u5929\u5C31\u7070\u7070\u7684";
+        final byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        final SimpleLiteral byteLiteral = new SimpleLiteral(inputBytes);
+        args.writeBytes(byteLiteral);
+        final Map<String, List<String>> capas = new HashMap<String, List<String>>();
+        capas.put(ImapClientConstants.LITERAL_PLUS, Arrays.asList(ImapClientConstants.LITERAL_PLUS));
+
+        final ImapRequest cmd = new SearchCommand(null, "UTF-8", args, new Capability(capas));
+        final ByteArrayOutputStream expectedOutput = new ByteArrayOutputStream();
+        final String cmdLine = "SEARCH CHARSET UTF-8 {15+}\r\n";
+        expectedOutput.write(cmdLine.getBytes(StandardCharsets.UTF_8));
+        expectedOutput.write(inputBytes);
+        expectedOutput.write('\r');
+        expectedOutput.write('\n');
+        final byte[] expected = expectedOutput.toByteArray();
+        final ByteBuf actual = cmd.getCommandLineBytes();
+        Assert.assertEquals(actual.readableBytes(), expected.length, "Expected result mismatched.");
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals(actual.getByte(i), expected[i], "byte mismatched in index:" + i);
+        }
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Literal implementation.
+     */
+    public class SimpleLiteral implements Literal {
+        /** Message Data as byte array. */
+        private final byte[] msgData;
+
+        /**
+         * Creates a byte literal.
+         *
+         * @param data - message data in ascii
+         */
+        public SimpleLiteral(final byte[] data) {
+            msgData = data;
+        }
+
+        @Override
+        public int size() {
+            return msgData.length;
+        }
+
+        @Override
+        public void writeTo(final OutputStream os) throws IOException {
+            os.write(msgData);
+        }
+
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNoneNullMessageSeqStringNonNullSearchTerm()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
+        final ImapRequest cmd = new SearchCommand("1:*", messageFlagTerms, null);
+        Assert.assertEquals(cmd.getCommandLine(), "SEARCH 1:* DELETED SEEN\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNullMessageSeqSetsNonNullSearchTerm()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final MessageNumberSet[] msgsets = null;
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
+        final ImapRequest cmd = new SearchCommand(msgsets, messageFlagTerms, null);
+        Assert.assertEquals(cmd.getCommandLine(), "SEARCH DELETED SEEN\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNoneNullMessageSeqSetsNullSearchTermNullCharset()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+        final int[] msgNos = { 1, 2, 3, 4 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgNos);
+        final FlagTerm messageFlagTerms = null;
+        final ImapRequest cmd = new SearchCommand(msgsets, messageFlagTerms, null);
+        Assert.assertEquals(cmd.getCommandLine(), "SEARCH 1:4\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNullMessageSeqSetsNullSearchTerm()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+        final MessageNumberSet[] msgSets = null;
+        final String charset = null;
+        ImapAsyncClientException actualEx = null;
+        try {
+            new SearchCommand(msgSets, null, null);
+        } catch (final ImapAsyncClientException ex) {
+            actualEx = ex;
+        }
+        Assert.assertNotNull(actualEx, "Expecting exception to be thrown");
+        Assert.assertEquals(actualEx.getFaiureType(), FailureType.INVALID_INPUT, "Incorrect failure type.");
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNullMessageSeqSetsNullArgument()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+        final String msgSeqs = null;
+        ImapAsyncClientException actualEx = null;
+        final Argument args = null;
+        final Capability capa = null;
+        try {
+            new SearchCommand(msgSeqs, "UTF-8", args, capa);
+        } catch (final ImapAsyncClientException ex) {
+            actualEx = ex;
+        }
+        Assert.assertNotNull(actualEx, "Expecting exception to be thrown");
+        Assert.assertEquals(actualEx.getFaiureType(), FailureType.INVALID_INPUT, "Incorrect failure type.");
     }
 
     /**
@@ -87,12 +299,16 @@ public class SearchCommandTest {
     @Test
     public void testGetCommandLineWithNoneAscii()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
-        final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
+        final int[] msgNos = { 1, 2, 3 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgNos);
 
         final SubjectTerm term = new SubjectTerm("ΩΩ"); // have none-ascii characters
-        final ImapRequest cmd = new SearchCommand(msgsets, term);
-        Assert.assertEquals(cmd.getCommandLine(), "SEARCH CHARSET UTF-8 SUBJECT {4+}\r\nￎﾩￎﾩ 1:3\r\n", "Expected result mismatched.");
+
+        final Map<String, List<String>> capas = new HashMap<String, List<String>>();
+        capas.put(ImapClientConstants.LITERAL_PLUS, Arrays.asList(ImapClientConstants.LITERAL_PLUS));
+
+        final ImapRequest cmd = new SearchCommand(msgsets, term, new Capability(capas));
+        Assert.assertEquals(cmd.getCommandLine(), "SEARCH CHARSET UTF-8 1:3 SUBJECT {4+}\r\n����\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -101,4 +317,17 @@ public class SearchCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws IOException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandType() throws ImapAsyncClientException, SearchException, IOException {
+        final Capability capa = null;
+        final ImapRequest cmd = new SearchCommand(new MessageNumberSet[] { new MessageNumberSet(1, LastMessage.LAST_MESSAGE) }, null, capa);
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.SEARCH);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/SelectFolderCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/SelectFolderCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.SelectFolderCommand;
 
 /**
  * Unit test for {@code SelectFolderCommand}.
@@ -92,5 +90,14 @@ public class SelectFolderCommandTest {
         final String folderName = "测试";
         final ImapRequest cmd = new SelectFolderCommand(folderName);
         Assert.assertEquals(cmd.getCommandLine(), SELECT + "&bUuL1Q-\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new SelectFolderCommand("inbox");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.SELECT_FOLDER);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/StatusCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/StatusCommandTest.java
@@ -132,4 +132,13 @@ public class StatusCommandTest {
         Assert.assertEquals(ex.getFaiureType(), ImapAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
                 "Expected result mismatched.");
     }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new StatusCommand("inbox", ALL_ITEMS);
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.STATUS);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/StoreFlagsCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/StoreFlagsCommandTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.sun.mail.imap.protocol.IMAPResponse;
-import com.sun.mail.imap.protocol.MessageSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
 
 /**
@@ -44,7 +44,7 @@ public class StoreFlagsCommandTest {
     }
 
     /**
-     * Tests getCommandLine method using Message sequences.
+     * Tests getCommandLine method using message sequences, flags, adding flags and not silent.
      *
      * @throws IOException will not throw
      * @throws IllegalAccessException will not throw
@@ -53,16 +53,15 @@ public class StoreFlagsCommandTest {
      * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithMessageSequence()
+    public void testGetCommandLineWithFlagsAddedNotSilent()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
 
         final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgs);
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
-        final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(msgsets, flags, isSet);
+        final ImapRequest cmd = new StoreFlagsCommand(msgsets, flags, FlagsAction.ADD);
         Assert.assertEquals(cmd.getCommandLine(), "STORE 1:3 +FLAGS (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
@@ -73,7 +72,93 @@ public class StoreFlagsCommandTest {
     }
 
     /**
-     * Tests getCommandLine method.
+     * Tests getCommandLine method using message sequences, flags, replacing flags and not silent.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithFlagsReplacedNotSilent()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final int[] msgs = { 1, 2, 3 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgs);
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final ImapRequest cmd = new StoreFlagsCommand(msgsets, flags, FlagsAction.REPLACE);
+        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:3 FLAGS (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method using message sequences, flags, adding flags and silent.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithFlagsAddedSilent()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final int[] msgs = { 1, 2, 3 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgs);
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final boolean isSilent = true;
+        final ImapRequest cmd = new StoreFlagsCommand(msgsets, flags, FlagsAction.ADD, isSilent);
+        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:3 +FLAGS.SILENT (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method using message sequences, flags, replacing flags and silent.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithFlagsReplacedSilent()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final int[] msgs = { 1, 2, 3 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgs);
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final boolean isSilent = true;
+        final ImapRequest cmd = new StoreFlagsCommand(msgsets, flags, FlagsAction.REPLACE, isSilent);
+        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:3 FLAGS.SILENT (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with message sequences, flags, removing flags and not silent.
      *
      * @throws IOException will not throw
      * @throws IllegalAccessException will not throw
@@ -81,15 +166,64 @@ public class StoreFlagsCommandTest {
      * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithStartEndConstructorAndRemoveFlags()
+    public void testGetCommandLineWithFlagsRemovedNotSilent() throws IOException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final ImapRequest cmd = new StoreFlagsCommand(new MessageNumberSet[] { new MessageNumberSet(1, 10000) }, flags, FlagsAction.REMOVE);
+        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:10000 -FLAGS (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with message sequences, removing flags and silent.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithFlagsRemovedAndSilent() throws IOException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final boolean isSilent = true;
+        final ImapRequest cmd = new StoreFlagsCommand(new MessageNumberSet[] { new MessageNumberSet(1, 10000) }, flags, FlagsAction.REMOVE, isSilent);
+        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:10000 -FLAGS.SILENT (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with message sequences, adding flags and silent.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithMessageSeqStringFlagsAddedAndSilent()
             throws IOException, IllegalAccessException, SearchException, ImapAsyncClientException {
 
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
-        final boolean isSet = false;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
-        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:10000 -FLAGS (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+        final boolean isSilent = true;
+        final ImapRequest cmd = new StoreFlagsCommand("1:*", flags, FlagsAction.ADD, isSilent);
+        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:* +FLAGS.SILENT (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -107,8 +241,7 @@ public class StoreFlagsCommandTest {
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
-        final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
+        final ImapRequest cmd = new StoreFlagsCommand(new MessageNumberSet[] { new MessageNumberSet(1, 10000) }, flags, FlagsAction.ADD);
         Assert.assertNull(cmd.getStreamingResponsesQueue(), "Expected result mismatched.");
     }
 
@@ -121,8 +254,7 @@ public class StoreFlagsCommandTest {
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
-        final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
+        final ImapRequest cmd = new StoreFlagsCommand(new MessageNumberSet[] { new MessageNumberSet(1, 10000) }, flags, FlagsAction.ADD);
         final IMAPResponse serverResponse = null; // null or not null does not matter
         ImapAsyncClientException ex = null;
         try {
@@ -144,8 +276,7 @@ public class StoreFlagsCommandTest {
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
-        final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
+        final ImapRequest cmd = new StoreFlagsCommand(new MessageNumberSet[] { new MessageNumberSet(1, 10000) }, flags, FlagsAction.ADD);
         ImapAsyncClientException ex = null;
         try {
             cmd.getTerminateCommandLine();
@@ -155,5 +286,35 @@ public class StoreFlagsCommandTest {
         Assert.assertNotNull(ex, "Expect exception to be thrown.");
         Assert.assertEquals(ex.getFaiureType(), ImapAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
                 "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final ImapRequest cmd = new StoreFlagsCommand(new MessageNumberSet[] { new MessageNumberSet(1, 10000) }, flags, FlagsAction.ADD);
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.STORE_FLAGS);
+    }
+
+    /**
+     * Tests enum.
+     */
+    @Test
+    public void testFlagsActionEnum() {
+        final FlagsAction[] enumList = FlagsAction.values();
+        Assert.assertEquals(enumList.length, 3, "The enum count mismatched.");
+        // values below cannot be changed
+        final FlagsAction add = FlagsAction.valueOf("ADD");
+        Assert.assertSame(add, FlagsAction.ADD, "Enum does not match.");
+
+        final FlagsAction replace = FlagsAction.valueOf("REPLACE");
+        Assert.assertSame(replace, FlagsAction.REPLACE, "Enum does not match.");
+
+        final FlagsAction remove = FlagsAction.valueOf("REMOVE");
+        Assert.assertSame(remove, FlagsAction.REMOVE, "Enum does not match.");
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/SubscribeFolderCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/SubscribeFolderCommandTest.java
@@ -13,9 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.SubscribeFolderCommand;
-
 
 /**
  * Unit test for {@code SubscribeFolderCommand}.
@@ -93,5 +90,14 @@ public class SubscribeFolderCommandTest {
         final String folderName = "测试";
         final ImapRequest cmd = new SubscribeFolderCommand(folderName);
         Assert.assertEquals(cmd.getCommandLine(), SUBSCRIBE + "&bUuL1Q-\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new SubscribeFolderCommand("vacation");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.SUBSCRIBE);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/UidCopyMessageCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/UidCopyMessageCommandTest.java
@@ -12,11 +12,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.sun.mail.imap.protocol.MessageSet;
 import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.UidCopyMessageCommand;
 
 /**
  * Unit test for {@code UidCopyMessageCommand}.
@@ -94,4 +92,36 @@ public class UidCopyMessageCommandTest {
         }
     }
 
+    /**
+     * Tests the constructor with @{MessageNumberSet} and getCommandLine method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testConstructorMessageNumberSetGetCommandLine()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final String folderName = "folderABC";
+        final MessageNumberSet[] mset = MessageNumberSet.createMessageNumberSets(new long[] { 37850L, 37851L, 37852L });
+        final ImapRequest cmd = new UidCopyMessageCommand(mset, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "UID COPY 37850:37852 folderABC\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new UidCopyMessageCommand("37850:37852", "savedFolder");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.UID_COPY_MESSAGE);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/UidExpungeCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/UidExpungeCommandTest.java
@@ -13,9 +13,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.UidExpungeCommand;
 
 /**
  * Unit test for {@code UidExpungeCommand}.
@@ -81,6 +80,43 @@ public class UidExpungeCommandTest {
     }
 
     /**
+     * Tests getCommandLine method with MessageNumberSet constructor.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithMessageNumberSet()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        {
+            final MessageNumberSet[] sets = { new MessageNumberSet(43, 4294967295L) };
+            final ImapRequest cmd = new UidExpungeCommand(sets);
+            Assert.assertEquals(cmd.getCommandLine(), "UID EXPUNGE 43:4294967295\r\n", "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+        {
+            long[] uids = { 4294967292L, 4294967293L, 4294967294L };
+            final MessageNumberSet[] sets = MessageNumberSet.createMessageNumberSets(uids);
+            final ImapRequest cmd = new UidExpungeCommand(sets);
+            Assert.assertEquals(cmd.getCommandLine(), "UID EXPUNGE 4294967292:4294967294\r\n", "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+    }
+
+    /**
      * Tests getCommandLine method.
      *
      * @throws ImapAsyncClientException will not throw
@@ -101,4 +137,12 @@ public class UidExpungeCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new UidExpungeCommand("43:44,99");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.UID_EXPUNGE);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/UidMoveMessageCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/UidMoveMessageCommandTest.java
@@ -12,11 +12,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.sun.mail.imap.protocol.MessageSet;
 import com.sun.mail.imap.protocol.UIDSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.UidMoveMessageCommand;
 
 /**
  * Unit test for {@code UidMoveMessageCommand}.
@@ -94,4 +92,36 @@ public class UidMoveMessageCommandTest {
         }
     }
 
+    /**
+     * Tests the constructor with @{MessageNumberSet} and getCommandLine method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testConstructorMessageNumberSetGetCommandLine()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final String folderName = "folderABC";
+        final MessageNumberSet[] mset = MessageNumberSet.createMessageNumberSets(new long[] { 37850L, 37851L, 37852L });
+        final ImapRequest cmd = new UidMoveMessageCommand(mset, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "UID MOVE 37850:37852 folderABC\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new UidMoveMessageCommand("37850:37852", "targetFolder");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.UID_MOVE_MESSAGE);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/UidSearchCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/UidSearchCommandTest.java
@@ -1,9 +1,16 @@
 package com.yahoo.imapnio.async.request;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.mail.Flags;
@@ -15,10 +22,15 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.sun.mail.imap.protocol.UIDSet;
+import com.sun.mail.iap.Argument;
+import com.sun.mail.iap.Literal;
+import com.yahoo.imapnio.async.data.Capability;
+import com.yahoo.imapnio.async.data.MessageNumberSet;
+import com.yahoo.imapnio.async.data.MessageNumberSet.LastMessage;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.UidSearchCommand;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException.FailureType;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Unit test for {@code UidSearchCommand}.
@@ -47,7 +59,7 @@ public class UidSearchCommandTest {
     }
 
     /**
-     * Tests getCommandLine method using Message sequences.
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
      *
      * @throws IOException will not throw
      * @throws IllegalAccessException will not throw
@@ -56,23 +68,133 @@ public class UidSearchCommandTest {
      * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithUIDSequence()
+    public void testGetCommandLineNoneNullMessageSeqSetsNonNullSearchTerm()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
-
-        final long[] msgs = { 4294967292L, 4294967294L, 4294967295L };
-        final UIDSet[] uidsets = UIDSet.createUIDSets(msgs);
+        final int[] msgNos = { 1, 2, 3 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgNos);
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
         final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
-        final ImapRequest cmd = new UidSearchCommand(uidsets, messageFlagTerms);
-        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH DELETED SEEN 4294967292,4294967294:4294967295\r\n", "Expected result mismatched.");
+        final Capability capa = null;
+        final ImapRequest cmd = new UidSearchCommand(msgsets, messageFlagTerms, capa);
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH 1:3 DELETED SEEN\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
         for (final Field field : fieldsToCheck) {
             Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
         }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNoneNullMessageSeqStringNonNullSearchTerm()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
+        final Capability capa = null;
+        final ImapRequest cmd = new UidSearchCommand("1:*", messageFlagTerms, capa);
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH 1:* DELETED SEEN\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNullMessageSeqSetsNonNullSearchTerm()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final MessageNumberSet[] msgsets = null;
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
+
+        final Capability capa = null;
+        final ImapRequest cmd = new UidSearchCommand(msgsets, messageFlagTerms, capa);
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH DELETED SEEN\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNoneNullMessageSeqSetsNullSearchTermNullCharset()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+        final int[] msgNos = { 1, 2, 3, 4 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgNos);
+        final FlagTerm messageFlagTerms = null;
+
+        final Capability capa = null;
+        final ImapRequest cmd = new UidSearchCommand(msgsets, messageFlagTerms, capa);
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH 1:4\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNullMessageSeqSetsNullSearchTerm()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+        final MessageNumberSet[] msgSets = null;
+        final String charset = null;
+        ImapAsyncClientException actualEx = null;
+        final Capability capa = null;
+        try {
+            new UidSearchCommand(msgSets, null, capa);
+        } catch (final ImapAsyncClientException ex) {
+            actualEx = ex;
+        }
+        Assert.assertNotNull(actualEx, "Expecting exception to be thrown");
+        Assert.assertEquals(actualEx.getFaiureType(), FailureType.INVALID_INPUT, "Incorrect failure type.");
     }
 
     /**
@@ -87,12 +209,15 @@ public class UidSearchCommandTest {
     @Test
     public void testGetCommandLineWithNoneAscii()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
-        final long[] msgs = { 1L, 2L, 3L };
-        final UIDSet[] uidsets = UIDSet.createUIDSets(msgs);
+        final int[] msgNos = { 1, 2, 3 };
+        final MessageNumberSet[] msgsets = MessageNumberSet.createMessageNumberSets(msgNos);
 
         final SubjectTerm term = new SubjectTerm("ΩΩ"); // have none-ascii characters
-        final ImapRequest cmd = new UidSearchCommand(uidsets, term);
-        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH CHARSET UTF-8 SUBJECT {4+}\r\nￎﾩￎﾩ 1:3\r\n", "Expected result mismatched.");
+
+        final Map<String, List<String>> capas = new HashMap<String, List<String>>();
+        capas.put(ImapClientConstants.LITERAL_PLUS, Arrays.asList(ImapClientConstants.LITERAL_PLUS));
+        final ImapRequest cmd = new UidSearchCommand(msgsets, term, new Capability(capas));
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH CHARSET UTF-8 1:3 SUBJECT {4+}\r\n����\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -102,23 +227,41 @@ public class UidSearchCommandTest {
     }
 
     /**
-     * Tests getCommandLine method using UID.
+     * Tests getCommandLine method with Literal+.
      *
      * @throws IOException will not throw
      * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
      * @throws ImapAsyncClientException will not throw
      * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithUID() throws IOException, IllegalAccessException, SearchException, ImapAsyncClientException {
-        final long[] msgs = { 4294967292L, 4294967294L, 4294967295L };
-        final UIDSet[] uidsets = UIDSet.createUIDSets(msgs);
-        final Flags flags = new Flags();
-        flags.add(Flags.Flag.SEEN);
-        flags.add(Flags.Flag.DELETED);
-        final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
-        final ImapRequest cmd = new UidSearchCommand(uidsets, messageFlagTerms);
-        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH DELETED SEEN 4294967292,4294967294:4294967295\r\n", "Expected result mismatched.");
+    public void testGetCommandLineWithLiteralPlusCapaEnabled()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Argument args = new Argument();
+
+        // Chinese input: \u5929\u5c31\u7070\u7070\u7684
+        final String input = "\u5929\u5C31\u7070\u7070\u7684";
+        final byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        final SimpleLiteral byteLiteral = new SimpleLiteral(inputBytes);
+        args.writeBytes(byteLiteral);
+
+        final Map<String, List<String>> capas = new HashMap<String, List<String>>();
+        capas.put(ImapClientConstants.LITERAL_PLUS, Arrays.asList(ImapClientConstants.LITERAL_PLUS));
+        final ImapRequest cmd = new UidSearchCommand(null, "UTF-8", args, new Capability(capas));
+        final ByteArrayOutputStream expectedOutput = new ByteArrayOutputStream();
+        final String cmdLine = "UID SEARCH CHARSET UTF-8 {15+}\r\n";
+        expectedOutput.write(cmdLine.getBytes(StandardCharsets.UTF_8));
+        expectedOutput.write(inputBytes);
+        expectedOutput.write('\r');
+        expectedOutput.write('\n');
+        final byte[] expected = expectedOutput.toByteArray();
+        final ByteBuf actual = cmd.getCommandLineBytes();
+        Assert.assertEquals(actual.readableBytes(), expected.length, "Expected result mismatched.");
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals(actual.getByte(i), expected[i], "byte mismatched in index:" + i);
+        }
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -127,4 +270,162 @@ public class UidSearchCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandLine method without Literal+.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithoutLiteralPlusCapaEnabled()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Argument args = new Argument();
+
+        // Chinese input: \u5929\u5c31\u7070\u7070\u7684
+        final String input = "\u5929\u5C31\u7070\u7070\u7684";
+        final byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        final SimpleLiteral byteLiteral = new SimpleLiteral(inputBytes);
+        args.writeBytes(byteLiteral);
+
+        final Capability capa = null;
+        final ImapRequest cmd = new UidSearchCommand(null, "UTF-8", args, capa);
+        final ByteArrayOutputStream expectedOutput = new ByteArrayOutputStream();
+        final String cmdLine = "UID SEARCH CHARSET UTF-8 {15}\r\n";
+        expectedOutput.write(cmdLine.getBytes(StandardCharsets.UTF_8));
+        expectedOutput.write(inputBytes);
+        expectedOutput.write('\r');
+        expectedOutput.write('\n');
+        final byte[] expected = expectedOutput.toByteArray();
+        final ByteBuf actual = cmd.getCommandLineBytes();
+        Assert.assertEquals(actual.readableBytes(), expected.length, "Expected result mismatched.");
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals(actual.getByte(i), expected[i], "byte mismatched in index:" + i);
+        }
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNullArgumentNoneNullMessageSequence()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Argument args = null;
+        final String msgSeq = "1:*";
+        final Map<String, List<String>> capas = new HashMap<String, List<String>>();
+        capas.put(ImapClientConstants.LITERAL_PLUS, Arrays.asList(ImapClientConstants.LITERAL_PLUS));
+        final ImapRequest cmd = new UidSearchCommand(msgSeq, null, args, new Capability(capas));
+        final ByteArrayOutputStream expectedOutput = new ByteArrayOutputStream();
+        final String cmdLine = "UID SEARCH 1:*\r\n";
+        expectedOutput.write(cmdLine.getBytes(StandardCharsets.UTF_8));
+
+        final byte[] expected = expectedOutput.toByteArray();
+        final ByteBuf actual = cmd.getCommandLineBytes();
+        Assert.assertEquals(actual.readableBytes(), expected.length, "Expected result mismatched.");
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals(actual.getByte(i), expected[i], "byte mismatched in index:" + i);
+        }
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method with none-null message sequences set, none-null SearchTerm.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineNoneNullMessageSequenceNoneNullArgument()
+            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
+
+        final Argument args = new Argument();
+        args.writeAtom("ALL");
+        args.writeAtom("UID");
+        final String msgSeq = "1:*";
+        final Map<String, List<String>> capas = new HashMap<String, List<String>>();
+        capas.put(ImapClientConstants.LITERAL_PLUS, Arrays.asList(ImapClientConstants.LITERAL_PLUS));
+        final ImapRequest cmd = new UidSearchCommand(msgSeq, null, args, new Capability(capas));
+        final ByteArrayOutputStream expectedOutput = new ByteArrayOutputStream();
+        final String cmdLine = "UID SEARCH 1:* ALL UID\r\n";
+        expectedOutput.write(cmdLine.getBytes(StandardCharsets.UTF_8));
+
+        final byte[] expected = expectedOutput.toByteArray();
+        final ByteBuf actual = cmd.getCommandLineBytes();
+        Assert.assertEquals(actual.readableBytes(), expected.length, "Expected result mismatched.");
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals(actual.getByte(i), expected[i], "byte mismatched in index:" + i);
+        }
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Literal implementation.
+     */
+    public class SimpleLiteral implements Literal {
+        /** Message Data as byte array. */
+        private final byte[] msgData;
+
+        /**
+         * Creates a byte literal.
+         *
+         * @param data - message data in ascii
+         */
+        public SimpleLiteral(final byte[] data) {
+            msgData = data;
+        }
+
+        @Override
+        public int size() {
+            return msgData.length;
+        }
+
+        @Override
+        public void writeTo(final OutputStream os) throws IOException {
+            os.write(msgData);
+        }
+
+    }
+
+    /**
+     * Tests getCommandType method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws IOException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandType() throws ImapAsyncClientException, SearchException, IOException {
+        final Capability capa = null;
+        final ImapRequest cmd = new UidSearchCommand(new MessageNumberSet[] { new MessageNumberSet(1, LastMessage.LAST_MESSAGE) }, null, capa);
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.UID_SEARCH);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/UnselectCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/UnselectCommandTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.UnselectCommand;
 
 /**
  * Unit test for {@code UnselectCommand}.
@@ -63,4 +61,12 @@ public class UnselectCommandTest {
         }
     }
 
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new UnselectCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.UNSELECT);
+    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/request/UnsubscribeFolderCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/UnsubscribeFolderCommandTest.java
@@ -13,9 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
-import com.yahoo.imapnio.async.request.ImapRequest;
-import com.yahoo.imapnio.async.request.UnsubscribeFolderCommand;
-
 
 /**
  * Unit test for {@code UnsubscribeFolderCommand}.
@@ -93,5 +90,14 @@ public class UnsubscribeFolderCommandTest {
         final String folderName = "测试";
         final ImapRequest cmd = new UnsubscribeFolderCommand(folderName);
         Assert.assertEquals(cmd.getCommandLine(), UNSUBSCRIBE + "&bUuL1Q-\r\n", "Expected result mismatched.");
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new UnsubscribeFolderCommand("testFolder");
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.UNSUBSCRIBE);
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/command/ArgumentTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/command/ArgumentTest.java
@@ -1,0 +1,78 @@
+package com.yahoo.imapnio.command;
+
+import java.io.IOException;
+
+import javax.mail.Flags;
+import javax.mail.internet.MimeUtility;
+import javax.mail.search.FlagTerm;
+import javax.mail.search.SearchException;
+import javax.mail.search.SubjectTerm;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.sun.mail.imap.protocol.SearchSequence;
+import com.yahoo.imapnio.command.Argument;
+
+/**
+ * Unit test for {@code Argument}.
+ */
+public class ArgumentTest {
+
+    /**
+     * Tests constructor and toString() method with null character set.
+     *
+     * @throws IOException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testConstructorAndToStringNullCharset() throws SearchException, IOException {
+
+        final SearchSequence searchSeq = new SearchSequence();
+        // message id
+        final String msgIds = "1:5";
+
+        // charset
+        final String charset = null;
+
+        // SearchTerm
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final FlagTerm term = new FlagTerm(flags, true);
+        final Argument args = new Argument();
+        args.append(searchSeq.generateSequence(term, null));
+
+        args.writeAtom(msgIds);
+
+        final String searchStr = args.toString();
+        Assert.assertEquals(searchStr, "DELETED SEEN 1:5", "result mismatched.");
+    }
+
+    /**
+     * Tests constructor and toString() method with null character set.
+     *
+     * @throws IOException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testConstructorAndToStringNoneNullCharset() throws SearchException, IOException {
+
+        final SearchSequence searchSeq = new SearchSequence();
+        // message id
+        final String msgIds = "1:5";
+
+        // charset
+        final String charset = "UTF-8";
+
+        // SearchTerm
+        final SubjectTerm term = new SubjectTerm("ΩΩ");
+        final Argument args = new Argument();
+        args.append(searchSeq.generateSequence(term, MimeUtility.javaCharset(charset)));
+
+        args.writeAtom(msgIds);
+
+        final String searchStr = args.toString();
+        Assert.assertEquals(searchStr, "SUBJECT {4+}\r\nￎﾩￎﾩ 1:5", "result mismatched.");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.7</version>
+    <version>3.0.0</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
1. Support getCommandType() in Imap command class.
2. Support ImapResponseParser to parse response from SearchCommand and UidSearchCommand to appropriate object.
3. Support MessageNumberSet to allow converting int or long array to its own, also supports last message
4. Fix bug: ImapResponseMapper in parsing to AppendUid.
5. Fix bug: Uid Search command to pass message sequences instead of UID.
6. Fix bug: fetch macro should not enclose parenthesis
7. Fix bug: store flags command with FlagsAction enum (replace, add, remove)
8. Fix bug: login command parameters need encoding
9. Fix bug: Auth plain with auth id
10. Support Append with Literal+.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

