### PR TITLE
Support Namespace command and fix session logging when channel is notified closed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>3.0.3</version>
+      <version>3.0.4</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ImapCommandType.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ImapCommandType.java
@@ -42,6 +42,8 @@ public enum ImapCommandType {
     LSUB,
     /** Move message command. */
     MOVE_MESSAGE,
+    /** Namespace command. */
+    NAMESPACE,
     /** Noop command. */
     NOOP,
     /** Rename folder command. */

--- a/core/src/main/java/com/yahoo/imapnio/async/request/NamespaceCommand.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/NamespaceCommand.java
@@ -1,0 +1,22 @@
+package com.yahoo.imapnio.async.request;
+
+/**
+ * This class defines IMAP NAMESPACE command request from client.
+ */
+public class NamespaceCommand extends AbstractNoArgsCommand {
+
+    /** Command name. */
+    private static final String NAMESPACE = "NAMESPACE";
+
+    /**
+     * Initializes the @{code NamespaceCommand}.
+     */
+    public NamespaceCommand() {
+        super(NAMESPACE);
+    }
+
+    @Override
+    public ImapCommandType getCommandType() {
+        return ImapCommandType.NAMESPACE;
+    }
+}

--- a/core/src/test/java/com/yahoo/imapnio/async/request/ImapCommandTypeTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/ImapCommandTypeTest.java
@@ -1,0 +1,21 @@
+package com.yahoo.imapnio.async.request;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@code ImapCommandType}.
+ */
+public class ImapCommandTypeTest {
+
+    /**
+     * Tests CommandType enum.
+     */
+    @Test
+    public void testCommandTypeEnum() {
+        final ImapCommandType[] enumList = ImapCommandType.values();
+        Assert.assertEquals(enumList.length, 35, "The enum count mismatched.");
+        final ImapCommandType uidFetch = ImapCommandType.valueOf("UID_FETCH");
+        Assert.assertSame(uidFetch, ImapCommandType.UID_FETCH, "Enum does not match.");
+    }
+}

--- a/core/src/test/java/com/yahoo/imapnio/async/request/NamespaceCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/NamespaceCommandTest.java
@@ -1,0 +1,72 @@
+package com.yahoo.imapnio.async.request;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.mail.search.SearchException;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+
+/**
+ * Unit test for {@code NamespaceCommand}.
+ */
+public class NamespaceCommandTest {
+
+    /** Fields to check for cleanup. */
+    private Set<Field> fieldsToCheck;
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        // Use reflection to get all declared non-primitive non-static fields (We do not care about inherited fields)
+        final Class<?> classUnderTest = NamespaceCommand.class;
+        fieldsToCheck = new HashSet<>();
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests getCommandLine method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testGetCommandLine() throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final ImapRequest cmd = new NamespaceCommand();
+        Assert.assertEquals(cmd.getCommandLine(), "NAMESPACE\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        final ImapRequest cmd = new NamespaceCommand();
+        Assert.assertSame(cmd.getCommandType(), ImapCommandType.NAMESPACE);
+    }
+}

--- a/core/src/test/java/com/yahoo/imapnio/async/request/UidFetchCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/UidFetchCommandTest.java
@@ -168,15 +168,4 @@ public class UidFetchCommandTest {
         final FetchMacro stateFull = FetchMacro.valueOf("FULL");
         Assert.assertSame(stateFull, FetchMacro.FULL, "Enum does not match.");
     }
-
-    /**
-     * Tests CommandType enum.
-     */
-    @Test
-    public void testCommandTypeEnum() {
-        final ImapCommandType[] enumList = ImapCommandType.values();
-        Assert.assertEquals(enumList.length, 34, "The enum count mismatched.");
-        final ImapCommandType uidFetch = ImapCommandType.valueOf("UID_FETCH");
-        Assert.assertSame(uidFetch, ImapCommandType.UID_FETCH, "Enum does not match.");
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request provides support for NAMESPACE command.
It also fixes the logging when channel is notified closed.  

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

