### PR TITLE
Bug fix for read timeout from caller perspective.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>3.0.6</version>
+      <version>3.0.7</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>3.0.6</version>
+        <version>3.0.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/client/ImapAsyncClient.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/client/ImapAsyncClient.java
@@ -103,7 +103,7 @@ public class ImapAsyncClient {
         /**
          * Initializes @{code ImapClientChannelInitializer} with the read time out value.
          *
-         * @param imapReadTimeoutValue timeout value for server not responding
+         * @param imapReadTimeoutValue timeout value for server not responding after write command is sent
          */
         private ImapClientChannelInitializer(final int imapReadTimeoutValue, final TimeUnit unit) {
             this.imapReadTimeoutValue = imapReadTimeoutValue;
@@ -114,8 +114,8 @@ public class ImapAsyncClient {
         protected void initChannel(final SocketChannel ch) {
             final ChannelPipeline pipeline = ch.pipeline();
 
-            // only enable read timeout
-            pipeline.addLast(IDLE_STATE_HANDLER_NAME, new IdleStateHandler(imapReadTimeoutValue, 0, 0, timeUnit)); // duplex
+            // setting all idle timeout to ensure event will only be triggered when both read and write not happened for the given time
+            pipeline.addLast(IDLE_STATE_HANDLER_NAME, new IdleStateHandler(0, 0, imapReadTimeoutValue, timeUnit)); // duplex
             pipeline.addLast(IMAP_LINE_DECODER_HANDLER_NAME, new ImapClientRespReader(Integer.MAX_VALUE)); // inbound
             pipeline.addLast(STRING_DECODER_HANDLER_NAME, new StringDecoder()); // inbound
             pipeline.addLast(STRING_ENCODER_HANDLER_NAME, new StringEncoder()); // outbound

--- a/core/src/main/java/com/yahoo/imapnio/async/client/ImapAsyncSessionConfig.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/client/ImapAsyncSessionConfig.java
@@ -18,7 +18,7 @@ public final class ImapAsyncSessionConfig {
     private int connectionTimeoutMillis = DEFAULT_CONNECTION_TIMEOUT_MILLIS;
 
     /**
-     * Maximum time in milliseconds for read timeout, this maps to the readIdleTime in @{code IdleStateHandler}.
+     * Maximum time in milliseconds for read timeout. The maximum time allowing no responses from server since client command sent.
      */
     private int readTimeoutMillis = DEFAULT_READ_TIMEOUT_MILLIS;
 
@@ -31,7 +31,7 @@ public final class ImapAsyncSessionConfig {
 
     /**
      * Sets the maximum time for opening a connection in milliseconds.
-     * 
+     *
      * @param connectionTimeoutMillis time in milliseconds
      */
     public void setConnectionTimeoutMillis(final int connectionTimeoutMillis) {
@@ -47,11 +47,10 @@ public final class ImapAsyncSessionConfig {
 
     /**
      * Sets the maximum time for read timeout, this means the time waiting for server to respond.
-     * 
+     *
      * @param readTimeoutMillis time in milliseconds
      */
     public void setReadTimeoutMillis(final int readTimeoutMillis) {
         this.readTimeoutMillis = readTimeoutMillis;
     }
-
 }

--- a/core/src/main/java/com/yahoo/imapnio/async/netty/ImapClientCommandRespHandler.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/netty/ImapClientCommandRespHandler.java
@@ -51,19 +51,18 @@ public class ImapClientCommandRespHandler extends MessageToMessageDecoder<IMAPRe
     public void userEventTriggered(final ChannelHandlerContext ctx, final Object msg) {
         if (msg instanceof IdleStateEvent) { // Handle the IdleState if needed
             final IdleStateEvent event = (IdleStateEvent) msg;
-            if (event.state() == IdleState.READER_IDLE) {
+            if (event.state() == IdleState.ALL_IDLE) {
                 // handle idle event in processor itself: when during idleCommand, we allow server not to send, but disallow during other commands
                 processor.handleIdleEvent(event);
             }
         }
     }
 
-	/**
-	 * Handles the event when a channel is closed(disconnected) either by server or
-	 * client.
-	 * 
-	 * @param ctx channel handler ctx
-	 */
+    /**
+     * Handles the event when a channel is closed(disconnected) either by server or client.
+     * 
+     * @param ctx channel handler ctx
+     */
     @Override
     public void channelInactive(final ChannelHandlerContext ctx) {
         if (processor == null) {

--- a/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncSessionConfigTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncSessionConfigTest.java
@@ -1,0 +1,27 @@
+package com.yahoo.imapnio.async.client;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@code ImapAsyncSessionConfig}.
+ */
+public class ImapAsyncSessionConfigTest {
+
+    /**
+     * Tests ImapAsyncSessionConfig constructor and getters.
+     */
+    @Test
+    public void testGettersSetters() {
+
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        final int connectionTimeout = 1000;
+        config.setConnectionTimeoutMillis(connectionTimeout);
+        Assert.assertEquals(config.getConnectionTimeoutMillis(), connectionTimeout, "Result mismatched.");
+
+        final int readTimeout = 2000;
+        config.setReadTimeoutMillis(readTimeout);
+        Assert.assertEquals(config.getReadTimeoutMillis(), readTimeout, "Result mismatched.");
+    }
+
+}

--- a/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientCommandRespHandlerTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientCommandRespHandlerTest.java
@@ -16,8 +16,6 @@ import org.testng.annotations.Test;
 
 import com.sun.mail.iap.ProtocolException;
 import com.sun.mail.imap.protocol.IMAPResponse;
-import com.yahoo.imapnio.async.netty.ImapClientCommandRespHandler;
-import com.yahoo.imapnio.async.netty.ImapCommandChannelEventProcessor;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.timeout.IdleState;
@@ -98,7 +96,7 @@ public class ImapClientCommandRespHandlerTest {
 
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         final IdleStateEvent idleEvent = Mockito.mock(IdleStateEvent.class);
-        Mockito.when(idleEvent.state()).thenReturn(IdleState.READER_IDLE);
+        Mockito.when(idleEvent.state()).thenReturn(IdleState.ALL_IDLE);
         handler.userEventTriggered(ctx, idleEvent);
         Mockito.verify(processor, Mockito.times(1)).handleIdleEvent(idleEvent);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.6</version>
+    <version>3.0.7</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
Read time out from caller's perspective should be counted from the "command write to server".
Before the fix, it was counting between 2 reads.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

