### PR TITLE
Change MAILBOXID from Integer to String in ExtensionMailboxInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>3.0.10</version>
+      <version>3.0.11</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>3.0.10</version>
+        <version>3.0.11</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfo.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfo.java
@@ -16,7 +16,7 @@ public class ExtensionMailboxInfo extends MailboxInfo {
     private static final String MAILBOX_ID = "MAILBOXID";
 
     /** Variable to store mailbox Id. */
-    private Integer mailboxId;
+    private String mailboxId;
 
     /**
      * Initializes an instance of @{code ExtensionMailboxInfo} from the server responses for the select or examine command.
@@ -47,7 +47,7 @@ public class ExtensionMailboxInfo extends MailboxInfo {
             if (key.equals(MAILBOX_ID)) { // example when 26 is the mailbox id:"* OK [MAILBOXID (26)] Ok"
                 final String[] values = ir.readSimpleList(); // reading the string, aka as above example, "(26)", within parentheses
                 if (values != null && values.length >= 1) {
-                    mailboxId = Integer.valueOf(values[0]);
+                    mailboxId = values[0];
                     resps[i] = null; // Nulls out this element in array to be consistent with MailboxInfo behavior
                     break;
                 }
@@ -60,7 +60,7 @@ public class ExtensionMailboxInfo extends MailboxInfo {
      * @return MAILBOXID, a server-allocated unique identifier for each mailbox. Please refer to OBJECTID, RFC 8474, for more detail.
      */
     @Nullable
-    public Integer getMailboxId() {
+    public String getMailboxId() {
         return mailboxId;
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
@@ -34,7 +34,7 @@ public class ExtensionMailboxInfoTest {
         content[4] = new IMAPResponse("* FLAGS (\\Answered \\Deleted \\Draft \\Flagged \\Seen $Forwarded $Junk $NotJunk)");
         content[5] = new IMAPResponse("* OK [PERMANENTFLAGS ()] No permanent flags permitted");
         content[6] = new IMAPResponse("* OK [HIGHESTMODSEQ 614]");
-        content[7] = new IMAPResponse("* OK [MAILBOXID (2147483647)] Ok");
+        content[7] = new IMAPResponse("* OK [MAILBOXID (214-mailbox)] Ok");
         content[8] = new IMAPResponse("002 OK [READ-ONLY] EXAMINE completed; now in selected state");
         final ExtensionMailboxInfo minfo = new ExtensionMailboxInfo(content);
 
@@ -49,7 +49,7 @@ public class ExtensionMailboxInfoTest {
         Assert.assertEquals(minfo.highestmodseq, 614, "highestmodseq mismatched.");
         Assert.assertEquals(minfo.uidvalidity, 1459808247, "uidvalidity mismatched.");
         Assert.assertEquals(minfo.uidnext, 150400, "uidnext mismatched.");
-        Assert.assertEquals(minfo.getMailboxId(), new Integer(2147483647), "MailboxId mismatched.");
+        Assert.assertEquals(minfo.getMailboxId(), "214-mailbox", "MailboxId mismatched.");
         Assert.assertNull(content[7], "This element should be nulled out");
     }
 

--- a/core/src/test/java/com/yahoo/imapnio/async/response/ImapResponseMapperTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/response/ImapResponseMapperTest.java
@@ -372,7 +372,7 @@ public class ImapResponseMapperTest {
         content[4] = new IMAPResponse("* FLAGS (\\Answered \\Deleted \\Draft \\Flagged \\Seen $Forwarded $Junk $NotJunk)");
         content[5] = new IMAPResponse("* OK [PERMANENTFLAGS ()] No permanent flags permitted");
         content[6] = new IMAPResponse("* OK [HIGHESTMODSEQ 614]");
-        content[7] = new IMAPResponse("* OK [MAILBOXID (26)] Ok");
+        content[7] = new IMAPResponse("* OK [MAILBOXID (A26)] Ok");
         content[8] = new IMAPResponse("002 OK [READ-ONLY] EXAMINE completed; now in selected state");
         final ExtensionMailboxInfo minfo = mapper.readValue(content, ExtensionMailboxInfo.class);
 
@@ -388,7 +388,7 @@ public class ImapResponseMapperTest {
         Assert.assertEquals(minfo.highestmodseq, 614, "highestmodseq mismatched.");
         Assert.assertEquals(minfo.uidvalidity, 1459808247, "uidvalidity mismatched.");
         Assert.assertEquals(minfo.uidnext, 150400, "uidnext mismatched.");
-        Assert.assertEquals(minfo.getMailboxId(), new Integer(26), "MailboxId mismatched.");
+        Assert.assertEquals(minfo.getMailboxId(), "A26", "MailboxId mismatched.");
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.10</version>
+    <version>3.0.11</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
Change MAILBOXID in ExtensionMailboxInfo from Integer to String.

## Description
Change the MAILBOXID in ExtensionMailboxInfo class from Integer to String to conform to the RFC 8474.

## Motivation and Context

## How Has This Been Tested?
The existing tests are changed to test MAILBOXID as String.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

