### PR TITLE
Adding failure type for unknown host exception and connect timeout exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>3.0.12</version>
+      <version>3.0.13</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>3.0.12</version>
+        <version>3.0.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/exception/ImapAsyncClientException.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/exception/ImapAsyncClientException.java
@@ -21,6 +21,12 @@ public class ImapAsyncClientException extends Exception {
         /** Connection failed with an exception. */
         CONNECTION_FAILED_EXCEPTION("Connection failed with an exception."),
 
+        /** Connection failed with unknown host exception. */
+        UNKNOWN_HOST_EXCEPTION("Connection failed with unknown host exception."),
+
+        /** Connection failed with connection timeout exception. */
+        CONNECTION_TIMEOUT_EXCEPTION("Connection failed with connection timeout exception."),
+
         /** Time-out on server connection. */
         CONNECTION_FAILED_EXCEED_IDLE_MAX("Time-out on server connection."),
 

--- a/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
@@ -640,9 +640,9 @@ public class ImapAsyncClientTest {
             Assert.assertNotNull(ex.getCause(), "Expect cause.");
             Assert.assertEquals(ex.getClass(), ExecutionException.class, "Class type mismatch.");
             final Exception exception = (Exception) ex.getCause();
-            Assert.assertTrue(exception instanceof ImapAsyncClientException, "exception type mismatch." + ex);
-            Assert.assertNotNull(exception.getCause(), "Cause should be unot be null");
-            Assert.assertTrue(exception.getCause() instanceof UnknownHostException, "Cause should be unknown host exception");
+            Assert.assertEquals(exception.getClass(), ImapAsyncClientException.class, "Exception class type mismatch.");
+            Assert.assertNotNull(exception.getCause(), "Cause should not be null");
+            Assert.assertEquals(exception.getCause().getClass(), UnknownHostException.class, "Cause should be unknown host exception");
             Assert.assertSame(exception.getCause(), nettyConnectFuture.cause(), "Cause should be same object");
             Assert.assertEquals(((ImapAsyncClientException) exception).getFaiureType(), FailureType.UNKNOWN_HOST_EXCEPTION,
                     "Exception type should be UNKNOWN_HOST_EXCEPTION");
@@ -725,9 +725,9 @@ public class ImapAsyncClientTest {
             Assert.assertNotNull(ex.getCause(), "Expect cause.");
             Assert.assertEquals(ex.getClass(), ExecutionException.class, "Class type mismatch.");
             final Exception exception = (Exception) ex.getCause();
-            Assert.assertTrue(exception instanceof ImapAsyncClientException, "exception type mismatch." + ex);
-            Assert.assertNotNull(exception.getCause(), "Cause should be unot be null");
-            Assert.assertTrue(exception.getCause() instanceof ConnectTimeoutException, "Cause should be connection timeout exception");
+            Assert.assertEquals(exception.getClass(), ImapAsyncClientException.class, "exception type mismatch." + ex);
+            Assert.assertNotNull(exception.getCause(), "Cause should not be null");
+            Assert.assertEquals(exception.getCause().getClass(), ConnectTimeoutException.class, "Cause should be connection timeout exception");
             Assert.assertSame(exception.getCause(), nettyConnectFuture.cause(), "Cause should be same object");
             Assert.assertEquals(((ImapAsyncClientException) exception).getFaiureType(), FailureType.CONNECTION_TIMEOUT_EXCEPTION,
                     "Exception type should be CONNECTION_TIMEOUT_EXCEPTION");

--- a/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
@@ -636,10 +636,14 @@ public class ImapAsyncClientTest {
             future.get(5, TimeUnit.MILLISECONDS);
             Assert.fail("Should throw unknown host exception");
         } catch (final ExecutionException | InterruptedException ex) {
-            Exception exception = ex instanceof ExecutionException && ex.getCause() instanceof Exception ? (Exception) ex.getCause() : ex;
+            Assert.assertNotNull(ex, "Expect exception to be thrown.");
+            Assert.assertNotNull(ex.getCause(), "Expect cause.");
+            Assert.assertEquals(ex.getClass(), ExecutionException.class, "Class type mismatch.");
+            final Exception exception = (Exception) ex.getCause();
             Assert.assertTrue(exception instanceof ImapAsyncClientException, "exception type mismatch." + ex);
             Assert.assertNotNull(exception.getCause(), "Cause should be unot be null");
             Assert.assertTrue(exception.getCause() instanceof UnknownHostException, "Cause should be unknown host exception");
+            Assert.assertSame(exception.getCause(), nettyConnectFuture.cause(), "Cause should be same object");
             Assert.assertEquals(((ImapAsyncClientException) exception).getFaiureType(), FailureType.UNKNOWN_HOST_EXCEPTION,
                     "Exception type should be UNKNOWN_HOST_EXCEPTION");
         }
@@ -674,7 +678,6 @@ public class ImapAsyncClientTest {
         final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
         config.setConnectionTimeoutMillis(5000);
         config.setReadTimeoutMillis(6000);
-        ;
         final List<String> sniNames = null;
 
         // test create session
@@ -718,10 +721,14 @@ public class ImapAsyncClientTest {
             future.get(5, TimeUnit.MILLISECONDS);
             Assert.fail("Should throw connect timeout exception");
         } catch (final ExecutionException | InterruptedException ex) {
-            Exception exception = ex instanceof ExecutionException && ex.getCause() instanceof Exception ? (Exception) ex.getCause() : ex;
+            Assert.assertNotNull(ex, "Expect exception to be thrown.");
+            Assert.assertNotNull(ex.getCause(), "Expect cause.");
+            Assert.assertEquals(ex.getClass(), ExecutionException.class, "Class type mismatch.");
+            final Exception exception = (Exception) ex.getCause();
             Assert.assertTrue(exception instanceof ImapAsyncClientException, "exception type mismatch." + ex);
             Assert.assertNotNull(exception.getCause(), "Cause should be unot be null");
             Assert.assertTrue(exception.getCause() instanceof ConnectTimeoutException, "Cause should be connection timeout exception");
+            Assert.assertSame(exception.getCause(), nettyConnectFuture.cause(), "Cause should be same object");
             Assert.assertEquals(((ImapAsyncClientException) exception).getFaiureType(), FailureType.CONNECTION_TIMEOUT_EXCEPTION,
                     "Exception type should be CONNECTION_TIMEOUT_EXCEPTION");
         }

--- a/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
@@ -592,7 +592,6 @@ public class ImapAsyncClientTest {
         final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
         config.setConnectionTimeoutMillis(5000);
         config.setReadTimeoutMillis(6000);
-        ;
         final List<String> sniNames = null;
 
         // test create session

--- a/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/client/ImapAsyncClientTest.java
@@ -4,10 +4,13 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLException;
 
@@ -20,6 +23,7 @@ import org.testng.annotations.Test;
 import com.yahoo.imapnio.async.client.ImapAsyncClient.ImapClientChannelInitializer;
 import com.yahoo.imapnio.async.client.ImapAsyncSession.DebugMode;
 import com.yahoo.imapnio.async.exception.ImapAsyncClientException;
+import com.yahoo.imapnio.async.exception.ImapAsyncClientException.FailureType;
 import com.yahoo.imapnio.async.netty.ImapClientConnectHandler;
 import com.yahoo.imapnio.client.ImapClientRespReader;
 import com.yahoo.imapnio.command.ImapClientRespDecoder;
@@ -29,6 +33,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringDecoder;
@@ -556,6 +561,170 @@ public class ImapAsyncClientTest {
                 Mockito.eq("NA"), Mockito.eq("NA"), Mockito.eq("failure"), Mockito.eq("imaps://one.two.three.com:993"), Mockito.eq(null),
                 Mockito.isA(ImapAsyncClientException.class));
 
+    }
+
+    /**
+     * Tests createSession method with unknown host exception.
+     *
+     * @throws SSLException will not throw
+     * @throws URISyntaxException will not throw
+     * @throws Exception when calling operationComplete() at GenericFutureListenr
+     */
+    @Test
+    public void testCreateSessionUnknownHostConnectFailed() throws SSLException, URISyntaxException, Exception {
+
+        final Bootstrap bootstrap = Mockito.mock(Bootstrap.class);
+        final ChannelFuture nettyConnectFuture = Mockito.mock(ChannelFuture.class);
+        Mockito.when(nettyConnectFuture.isSuccess()).thenReturn(false);
+        final Channel nettyChannel = Mockito.mock(Channel.class);
+        final ChannelPipeline nettyPipeline = Mockito.mock(ChannelPipeline.class);
+        Mockito.when(nettyChannel.pipeline()).thenReturn(nettyPipeline);
+        Mockito.when(nettyConnectFuture.channel()).thenReturn(nettyChannel);
+        Mockito.when(nettyConnectFuture.cause()).thenReturn(new UnknownHostException("Unknown host"));
+        Mockito.when(bootstrap.connect(Mockito.anyString(), Mockito.anyInt())).thenReturn(nettyConnectFuture);
+
+        final EventLoopGroup group = Mockito.mock(EventLoopGroup.class);
+        final Logger logger = Mockito.mock(Logger.class);
+        Mockito.when(logger.isDebugEnabled()).thenReturn(true);
+
+        final ImapAsyncClient aclient = new ImapAsyncClient(bootstrap, group, logger);
+
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        config.setConnectionTimeoutMillis(5000);
+        config.setReadTimeoutMillis(6000);
+        ;
+        final List<String> sniNames = null;
+
+        // test create session
+        final InetSocketAddress localAddress = null;
+        final URI serverUri = new URI(SERVER_URI_STR);
+        final Future<ImapAsyncCreateSessionResponse> future = aclient.createSession(serverUri, config, localAddress, sniNames, DebugMode.DEBUG_OFF);
+
+        // verify session creation
+        Assert.assertNotNull(future, "Future for ImapAsyncSession should not be null.");
+
+        final ArgumentCaptor<ImapClientChannelInitializer> initializerCaptor = ArgumentCaptor.forClass(ImapClientChannelInitializer.class);
+        Mockito.verify(bootstrap, Mockito.times(1)).handler(initializerCaptor.capture());
+        Assert.assertEquals(initializerCaptor.getAllValues().size(), 1, "Unexpected count of ImapClientChannelInitializer.");
+        final ImapClientChannelInitializer initializer = initializerCaptor.getAllValues().get(0);
+
+        // should not call this connect
+        Mockito.verify(bootstrap, Mockito.times(0)).connect(Mockito.any(SocketAddress.class), Mockito.any(SocketAddress.class));
+        // should call following connect
+        Mockito.verify(bootstrap, Mockito.times(1)).connect(Mockito.anyString(), Mockito.anyInt());
+        final ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
+        Mockito.verify(nettyConnectFuture, Mockito.times(1)).addListener(listenerCaptor.capture());
+        Assert.assertEquals(listenerCaptor.getAllValues().size(), 1, "Unexpected count of ImapClientChannelInitializer.");
+
+        // verify GenericFutureListener.operationComplete()
+        final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
+        listener.operationComplete(nettyConnectFuture);
+        final ArgumentCaptor<ChannelHandler> handlerCaptorFirst = ArgumentCaptor.forClass(ChannelHandler.class);
+        Mockito.verify(nettyPipeline, Mockito.times(0)).addFirst(Mockito.anyString(), handlerCaptorFirst.capture());
+        Assert.assertEquals(handlerCaptorFirst.getAllValues().size(), 0, "number of handlers mismatched.");
+
+        final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
+        Mockito.verify(nettyPipeline, Mockito.times(0)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 0, "Unexpected count of ChannelHandler added.");
+        // verify logging messages
+        Mockito.verify(logger, Mockito.times(1)).error(Mockito.eq("[{},{}] connect operationComplete. result={}, imapServerUri={}, sniNames={}"),
+                Mockito.eq("NA"), Mockito.eq("NA"), Mockito.eq("failure"), Mockito.eq("imaps://one.two.three.com:993"), Mockito.eq(null),
+                Mockito.isA(ImapAsyncClientException.class));
+
+        Assert.assertTrue(future.isDone(), "Future should be done.");
+        try {
+            future.get(5, TimeUnit.MILLISECONDS);
+            Assert.fail("Should throw unknown host exception");
+        } catch (final ExecutionException | InterruptedException ex) {
+            Exception exception = ex instanceof ExecutionException && ex.getCause() instanceof Exception ? (Exception) ex.getCause() : ex;
+            Assert.assertTrue(exception instanceof ImapAsyncClientException, "exception type mismatch." + ex);
+            Assert.assertNotNull(exception.getCause(), "Cause should be unot be null");
+            Assert.assertTrue(exception.getCause() instanceof UnknownHostException, "Cause should be unknown host exception");
+            Assert.assertEquals(((ImapAsyncClientException) exception).getFaiureType(), FailureType.UNKNOWN_HOST_EXCEPTION,
+                    "Exception type should be UNKNOWN_HOST_EXCEPTION");
+        }
+    }
+
+    /**
+     * Tests createSession method with ConnectTimeout exception.
+     *
+     * @throws SSLException will not throw
+     * @throws URISyntaxException will not throw
+     * @throws Exception when calling operationComplete() at GenericFutureListenr
+     */
+    @Test
+    public void testCreateSessionConnecctionTimeoutFailed() throws SSLException, URISyntaxException, Exception {
+
+        final Bootstrap bootstrap = Mockito.mock(Bootstrap.class);
+        final ChannelFuture nettyConnectFuture = Mockito.mock(ChannelFuture.class);
+        Mockito.when(nettyConnectFuture.isSuccess()).thenReturn(false);
+        final Channel nettyChannel = Mockito.mock(Channel.class);
+        final ChannelPipeline nettyPipeline = Mockito.mock(ChannelPipeline.class);
+        Mockito.when(nettyChannel.pipeline()).thenReturn(nettyPipeline);
+        Mockito.when(nettyConnectFuture.channel()).thenReturn(nettyChannel);
+        Mockito.when(nettyConnectFuture.cause()).thenReturn(new ConnectTimeoutException("connection timed out"));
+        Mockito.when(bootstrap.connect(Mockito.anyString(), Mockito.anyInt())).thenReturn(nettyConnectFuture);
+
+        final EventLoopGroup group = Mockito.mock(EventLoopGroup.class);
+        final Logger logger = Mockito.mock(Logger.class);
+        Mockito.when(logger.isDebugEnabled()).thenReturn(true);
+
+        final ImapAsyncClient aclient = new ImapAsyncClient(bootstrap, group, logger);
+
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        config.setConnectionTimeoutMillis(5000);
+        config.setReadTimeoutMillis(6000);
+        ;
+        final List<String> sniNames = null;
+
+        // test create session
+        final InetSocketAddress localAddress = null;
+        final URI serverUri = new URI(SERVER_URI_STR);
+        final Future<ImapAsyncCreateSessionResponse> future = aclient.createSession(serverUri, config, localAddress, sniNames, DebugMode.DEBUG_OFF);
+
+        // verify session creation
+        Assert.assertNotNull(future, "Future for ImapAsyncSession should not be null.");
+
+        final ArgumentCaptor<ImapClientChannelInitializer> initializerCaptor = ArgumentCaptor.forClass(ImapClientChannelInitializer.class);
+        Mockito.verify(bootstrap, Mockito.times(1)).handler(initializerCaptor.capture());
+        Assert.assertEquals(initializerCaptor.getAllValues().size(), 1, "Unexpected count of ImapClientChannelInitializer.");
+        final ImapClientChannelInitializer initializer = initializerCaptor.getAllValues().get(0);
+
+        // should not call this connect
+        Mockito.verify(bootstrap, Mockito.times(0)).connect(Mockito.any(SocketAddress.class), Mockito.any(SocketAddress.class));
+        // should call following connect
+        Mockito.verify(bootstrap, Mockito.times(1)).connect(Mockito.anyString(), Mockito.anyInt());
+        final ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
+        Mockito.verify(nettyConnectFuture, Mockito.times(1)).addListener(listenerCaptor.capture());
+        Assert.assertEquals(listenerCaptor.getAllValues().size(), 1, "Unexpected count of ImapClientChannelInitializer.");
+
+        // verify GenericFutureListener.operationComplete()
+        final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
+        listener.operationComplete(nettyConnectFuture);
+        final ArgumentCaptor<ChannelHandler> handlerCaptorFirst = ArgumentCaptor.forClass(ChannelHandler.class);
+        Mockito.verify(nettyPipeline, Mockito.times(0)).addFirst(Mockito.anyString(), handlerCaptorFirst.capture());
+        Assert.assertEquals(handlerCaptorFirst.getAllValues().size(), 0, "number of handlers mismatched.");
+
+        final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
+        Mockito.verify(nettyPipeline, Mockito.times(0)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 0, "Unexpected count of ChannelHandler added.");
+        // verify logging messages
+        Mockito.verify(logger, Mockito.times(1)).error(Mockito.eq("[{},{}] connect operationComplete. result={}, imapServerUri={}, sniNames={}"),
+                Mockito.eq("NA"), Mockito.eq("NA"), Mockito.eq("failure"), Mockito.eq("imaps://one.two.three.com:993"), Mockito.eq(null),
+                Mockito.isA(ImapAsyncClientException.class));
+
+        Assert.assertTrue(future.isDone(), "Future should be done.");
+        try {
+            future.get(5, TimeUnit.MILLISECONDS);
+            Assert.fail("Should throw connect timeout exception");
+        } catch (final ExecutionException | InterruptedException ex) {
+            Exception exception = ex instanceof ExecutionException && ex.getCause() instanceof Exception ? (Exception) ex.getCause() : ex;
+            Assert.assertTrue(exception instanceof ImapAsyncClientException, "exception type mismatch." + ex);
+            Assert.assertNotNull(exception.getCause(), "Cause should be unot be null");
+            Assert.assertTrue(exception.getCause() instanceof ConnectTimeoutException, "Cause should be connection timeout exception");
+            Assert.assertEquals(((ImapAsyncClientException) exception).getFaiureType(), FailureType.CONNECTION_TIMEOUT_EXCEPTION,
+                    "Exception type should be CONNECTION_TIMEOUT_EXCEPTION");
+        }
     }
 
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/exception/ImapAsyncClientExceptionTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/exception/ImapAsyncClientExceptionTest.java
@@ -59,6 +59,6 @@ public class ImapAsyncClientExceptionTest {
     public void testFailureType() {
         final ImapAsyncClientException.FailureType failureType = ImapAsyncClientException.FailureType.valueOf("CHANNEL_DISCONNECTED");
         Assert.assertEquals(failureType, ImapAsyncClientException.FailureType.CHANNEL_DISCONNECTED, "result mismatched.");
-        Assert.assertEquals(ImapAsyncClientException.FailureType.values().length, 14, "Number of enums mismatched.");
+        Assert.assertEquals(ImapAsyncClientException.FailureType.values().length, 16, "Number of enums mismatched.");
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientConnectHandlerTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientConnectHandlerTest.java
@@ -225,7 +225,7 @@ public class ImapClientConnectHandlerTest {
         final ImapClientConnectHandler handler = new ImapClientConnectHandler(imapFuture, logger, DebugMode.DEBUG_ON, SESSION_ID, sessCtx);
 
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
-        final ConnectTimeoutException connectTimeoutEx = new ConnectTimeoutException("Unknown host");
+        final ConnectTimeoutException connectTimeoutEx = new ConnectTimeoutException("connection timeout");
         handler.exceptionCaught(ctx, connectTimeoutEx);
 
         Assert.assertTrue(imapFuture.isDone(), "Future should be done");

--- a/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientConnectHandlerTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientConnectHandlerTest.java
@@ -3,6 +3,7 @@ package com.yahoo.imapnio.async.netty;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -27,6 +28,7 @@ import com.yahoo.imapnio.async.exception.ImapAsyncClientException.FailureType;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 
@@ -167,6 +169,79 @@ public class ImapClientConnectHandlerTest {
         Assert.assertNotNull(ex, "Expect exception to be thrown.");
         Assert.assertNotNull(ex.getCause(), "Expect cause.");
         Assert.assertEquals(ex.getCause().getClass(), ImapAsyncClientException.class, "Expected result mismatched.");
+    }
+
+    /**
+     * Tests exceptionCaught method with unKnownHostException.
+     *
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws InterruptedException will not throw
+     * @throws TimeoutException will not throw
+     */
+    @Test
+    public void testExceptionCaughtWithUnKnownHost() throws IllegalArgumentException, IllegalAccessException, InterruptedException, TimeoutException {
+        final ImapFuture<ImapAsyncCreateSessionResponse> imapFuture = new ImapFuture<ImapAsyncCreateSessionResponse>();
+        final Logger logger = Mockito.mock(Logger.class);
+
+        final String sessCtx = "Titanosauria@long.neck";
+        final ImapClientConnectHandler handler = new ImapClientConnectHandler(imapFuture, logger, DebugMode.DEBUG_ON, SESSION_ID, sessCtx);
+
+        final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        final UnknownHostException unknownHostEx = new UnknownHostException("Unknown host");
+        handler.exceptionCaught(ctx, unknownHostEx);
+
+        ExecutionException ex = null;
+        Assert.assertTrue(imapFuture.isDone(), "Future should be done");
+        try {
+            imapFuture.get(5, TimeUnit.MILLISECONDS);
+        } catch (final ExecutionException ee) {
+            ex = ee;
+        }
+        Assert.assertNotNull(ex, "Expect exception to be thrown.");
+        Assert.assertNotNull(ex.getCause(), "Expect cause.");
+        Assert.assertEquals(ex.getCause().getClass(), ImapAsyncClientException.class, "Expected result mismatched.");
+        final ImapAsyncClientException imapEx = (ImapAsyncClientException) ex.getCause();
+        Assert.assertNotNull(imapEx.getCause(), "expect cause");
+        Assert.assertTrue(imapEx.getCause() instanceof UnknownHostException, "Cause should be UnknownHost exception.");
+        Assert.assertEquals(imapEx.getFaiureType(), FailureType.UNKNOWN_HOST_EXCEPTION, "Failure type mismatch");
+    }
+
+    /**
+     * Tests exceptionCaught method with ConnectTimeout exception.
+     *
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     * @throws InterruptedException will not throw
+     * @throws TimeoutException will not throw
+     */
+    @Test
+    public void testExceptionCaughtWithConnectTimeoutException()
+            throws IllegalArgumentException, IllegalAccessException, InterruptedException, TimeoutException {
+        final ImapFuture<ImapAsyncCreateSessionResponse> imapFuture = new ImapFuture<ImapAsyncCreateSessionResponse>();
+        final Logger logger = Mockito.mock(Logger.class);
+
+        final String sessCtx = "Titanosauria@long.neck";
+        final ImapClientConnectHandler handler = new ImapClientConnectHandler(imapFuture, logger, DebugMode.DEBUG_ON, SESSION_ID, sessCtx);
+
+        final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        final ConnectTimeoutException connectTimeoutEx = new ConnectTimeoutException("Unknown host");
+        handler.exceptionCaught(ctx, connectTimeoutEx);
+
+        Assert.assertTrue(imapFuture.isDone(), "Future should be done");
+        ExecutionException ex = null;
+        try {
+            imapFuture.get(5, TimeUnit.MILLISECONDS);
+        } catch (final ExecutionException ee) {
+            ex = ee;
+        }
+        Assert.assertNotNull(ex, "Expect exception to be thrown.");
+        Assert.assertNotNull(ex.getCause(), "Expect cause.");
+        Assert.assertEquals(ex.getCause().getClass(), ImapAsyncClientException.class, "Expected result mismatched.");
+        final ImapAsyncClientException imapEx = (ImapAsyncClientException) ex.getCause();
+        Assert.assertNotNull(imapEx.getCause(), "expect cause");
+        Assert.assertTrue(imapEx.getCause() instanceof ConnectTimeoutException, "Cause should be ConnectTimeout exception.");
+        Assert.assertEquals(imapEx.getFaiureType(), FailureType.CONNECTION_TIMEOUT_EXCEPTION, "Failure type mismatch");
     }
 
     /**

--- a/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientConnectHandlerTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/netty/ImapClientConnectHandlerTest.java
@@ -203,7 +203,7 @@ public class ImapClientConnectHandlerTest {
         Assert.assertEquals(ex.getCause().getClass(), ImapAsyncClientException.class, "Expected result mismatched.");
         final ImapAsyncClientException imapEx = (ImapAsyncClientException) ex.getCause();
         Assert.assertNotNull(imapEx.getCause(), "expect cause");
-        Assert.assertTrue(imapEx.getCause() instanceof UnknownHostException, "Cause should be UnknownHost exception.");
+        Assert.assertEquals(imapEx.getCause().getClass(), UnknownHostException.class, "Cause should be UnknownHost exception.");
         Assert.assertEquals(imapEx.getFaiureType(), FailureType.UNKNOWN_HOST_EXCEPTION, "Failure type mismatch");
     }
 
@@ -240,7 +240,7 @@ public class ImapClientConnectHandlerTest {
         Assert.assertEquals(ex.getCause().getClass(), ImapAsyncClientException.class, "Expected result mismatched.");
         final ImapAsyncClientException imapEx = (ImapAsyncClientException) ex.getCause();
         Assert.assertNotNull(imapEx.getCause(), "expect cause");
-        Assert.assertTrue(imapEx.getCause() instanceof ConnectTimeoutException, "Cause should be ConnectTimeout exception.");
+        Assert.assertEquals(imapEx.getCause().getClass(), ConnectTimeoutException.class, "Cause should be ConnectTimeout exception.");
         Assert.assertEquals(imapEx.getFaiureType(), FailureType.CONNECTION_TIMEOUT_EXCEPTION, "Failure type mismatch");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.12</version>
+    <version>3.0.13</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Added 2 different FailureType for Unknown host exception and connect timeout exception. 

## Motivation and Context
Imap Auth Capability task needs to know the type of connection failure. Based on connection failure, it will return a different error codes. For unknown host and connect timeout exceptions, Auth Capability Worker will return 400, but it will return 500 for all other types of exceptions. Current code doesn't differentiate between these exceptions. 

## How Has This Been Tested?
Added unit tests to verify.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

