### PR TITLE
Expose additional data for select/examine command when QRESYNC is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>3.0.12</version>
+      <version>3.0.13</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>3.0.13</version>
+      <version>3.0.14</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>3.0.12</version>
+        <version>3.0.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>3.0.13</version>
+        <version>3.0.14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfo.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfo.java
@@ -64,8 +64,7 @@ public class ExtensionMailboxInfo extends MailboxInfo {
                 closed = true;
                 resps[i] = null; // Nulls out this element in array to be consistent with MailboxInfo behavior
             } else if (ir.isTagged() && ir.isOK()) {
-                taggedResponse = ir;
-                resps[i] = null; // Nulls out this element in array to be consistent with MailboxInfo behavior
+                taggedResponse = ir; // Do not null this out as it is used by ImapResponseMapper.
             }
             ir.reset(); // default back the parsing index
         }

--- a/core/src/main/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfo.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfo.java
@@ -1,5 +1,7 @@
 package com.yahoo.imapnio.async.data;
 
+import java.util.ArrayList;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -23,9 +25,6 @@ public class ExtensionMailboxInfo extends MailboxInfo {
 
     /** Variable to store previously selected mailbox was closed implicitly. */
     private boolean closed;
-
-    /** Tagged response when the status is OK. */
-    private IMAPResponse taggedResponse;
 
     /**
      * Initializes an instance of @{code ExtensionMailboxInfo} from the server responses for the select or examine command.
@@ -64,7 +63,10 @@ public class ExtensionMailboxInfo extends MailboxInfo {
                 closed = true;
                 resps[i] = null; // Nulls out this element in array to be consistent with MailboxInfo behavior
             } else if (ir.isTagged() && ir.isOK()) {
-                taggedResponse = ir; // Do not null this out as it is used by ImapResponseMapper.
+                if (responses == null) {
+                    responses = new ArrayList<IMAPResponse>(1);
+                }
+                responses.add(ir); // Do not null this out as it is used by ImapResponseMapper.
             }
             ir.reset(); // default back the parsing index
         }
@@ -85,11 +87,4 @@ public class ExtensionMailboxInfo extends MailboxInfo {
         return closed;
     }
 
-    /**
-     * @return tagged response when response is OK.
-     */
-    @Nullable
-    public IMAPResponse getTaggedResponse() {
-        return taggedResponse;
-    }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
@@ -55,7 +55,7 @@ public class ExtensionMailboxInfoTest {
         Assert.assertNull(content[8], "This element should be nulled out");
         Assert.assertEquals(minfo.getTaggedResponse().toString(), "002 OK [READ-ONLY] EXAMINE completed; now in selected state",
                 "Tagged response mismatched");
-        Assert.assertNull(content[9], "This element should be nulled out");
+        Assert.assertNotNull(content[9], "This element should not be nulled out");
     }
 
     /**

--- a/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
@@ -53,7 +53,8 @@ public class ExtensionMailboxInfoTest {
         Assert.assertEquals(minfo.uidnext, 150400, "uidnext mismatched.");
         Assert.assertEquals(minfo.getMailboxId(), "214-mailbox", "MailboxId mismatched.");
         Assert.assertNull(content[8], "This element should be nulled out");
-        Assert.assertEquals(minfo.getTaggedResponse().toString(), "002 OK [READ-ONLY] EXAMINE completed; now in selected state",
+        Assert.assertNotNull(minfo.responses, "responses should not be null");
+        Assert.assertEquals(minfo.responses.get(0).toString(), "002 OK [READ-ONLY] EXAMINE completed; now in selected state",
                 "Tagged response mismatched");
         Assert.assertNotNull(content[9], "This element should not be nulled out");
     }
@@ -95,7 +96,7 @@ public class ExtensionMailboxInfoTest {
         Assert.assertNull(minfo.getMailboxId(), "MailboxId mismatched, should not be set.");
         Assert.assertNotNull(content[7], "This element should not be nulled out");
         Assert.assertEquals(content[7].getRest(), "[MAILBOXABC (2147483647)] Ok", "The index is not reset to the point of the status code.");
-        Assert.assertNotNull(minfo.getTaggedResponse(), "tagged response mismatched");
+        Assert.assertNotNull(minfo.responses, "responses should not be null");
     }
 
     /**

--- a/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/ExtensionMailboxInfoTest.java
@@ -26,20 +26,22 @@ public class ExtensionMailboxInfoTest {
     @Test
     public void testCreateExtensionMailboxInfoSuccess() throws IOException, ProtocolException, ImapAsyncClientException {
 
-        final IMAPResponse[] content = new IMAPResponse[9];
-        content[0] = new IMAPResponse("* 3 EXISTS");
-        content[1] = new IMAPResponse("* 0 RECENT");
-        content[2] = new IMAPResponse("* OK [UIDVALIDITY 1459808247] UIDs valid");
-        content[3] = new IMAPResponse("* OK [UIDNEXT 150400] Predicted next UID");
-        content[4] = new IMAPResponse("* FLAGS (\\Answered \\Deleted \\Draft \\Flagged \\Seen $Forwarded $Junk $NotJunk)");
-        content[5] = new IMAPResponse("* OK [PERMANENTFLAGS ()] No permanent flags permitted");
-        content[6] = new IMAPResponse("* OK [HIGHESTMODSEQ 614]");
-        content[7] = new IMAPResponse("* OK [MAILBOXID (214-mailbox)] Ok");
-        content[8] = new IMAPResponse("002 OK [READ-ONLY] EXAMINE completed; now in selected state");
+        final IMAPResponse[] content = new IMAPResponse[10];
+        content[0] = new IMAPResponse("* OK [CLOSED]");
+        content[1] = new IMAPResponse("* 3 EXISTS");
+        content[2] = new IMAPResponse("* 0 RECENT");
+        content[3] = new IMAPResponse("* OK [UIDVALIDITY 1459808247] UIDs valid");
+        content[4] = new IMAPResponse("* OK [UIDNEXT 150400] Predicted next UID");
+        content[5] = new IMAPResponse("* FLAGS (\\Answered \\Deleted \\Draft \\Flagged \\Seen $Forwarded $Junk $NotJunk)");
+        content[6] = new IMAPResponse("* OK [PERMANENTFLAGS ()] No permanent flags permitted");
+        content[7] = new IMAPResponse("* OK [HIGHESTMODSEQ 614]");
+        content[8] = new IMAPResponse("* OK [MAILBOXID (214-mailbox)] Ok");
+        content[9] = new IMAPResponse("002 OK [READ-ONLY] EXAMINE completed; now in selected state");
         final ExtensionMailboxInfo minfo = new ExtensionMailboxInfo(content);
 
         // verify the result
         Assert.assertNotNull(minfo, "result mismatched.");
+        Assert.assertTrue(minfo.isClosed(), "Closed flag mismatched");
         Assert.assertNotNull(minfo.availableFlags, "availableFlags mismatched.");
         Assert.assertTrue(minfo.availableFlags.contains(Flag.ANSWERED), "availableFlags mismatched.");
         Assert.assertTrue(minfo.availableFlags.contains(Flag.DELETED), "availableFlags mismatched.");
@@ -50,7 +52,10 @@ public class ExtensionMailboxInfoTest {
         Assert.assertEquals(minfo.uidvalidity, 1459808247, "uidvalidity mismatched.");
         Assert.assertEquals(minfo.uidnext, 150400, "uidnext mismatched.");
         Assert.assertEquals(minfo.getMailboxId(), "214-mailbox", "MailboxId mismatched.");
-        Assert.assertNull(content[7], "This element should be nulled out");
+        Assert.assertNull(content[8], "This element should be nulled out");
+        Assert.assertEquals(minfo.getTaggedResponse().toString(), "002 OK [READ-ONLY] EXAMINE completed; now in selected state",
+                "Tagged response mismatched");
+        Assert.assertNull(content[9], "This element should be nulled out");
     }
 
     /**
@@ -77,6 +82,7 @@ public class ExtensionMailboxInfoTest {
 
         // verify the result
         Assert.assertNotNull(minfo, "result mismatched.");
+        Assert.assertFalse(minfo.isClosed(), "Closed flag mismatched");
         Assert.assertNotNull(minfo.availableFlags, "availableFlags mismatched.");
         Assert.assertTrue(minfo.availableFlags.contains(Flag.ANSWERED), "availableFlags mismatched.");
         Assert.assertTrue(minfo.availableFlags.contains(Flag.DELETED), "availableFlags mismatched.");
@@ -89,6 +95,7 @@ public class ExtensionMailboxInfoTest {
         Assert.assertNull(minfo.getMailboxId(), "MailboxId mismatched, should not be set.");
         Assert.assertNotNull(content[7], "This element should not be nulled out");
         Assert.assertEquals(content[7].getRest(), "[MAILBOXABC (2147483647)] Ok", "The index is not reset to the point of the status code.");
+        Assert.assertNotNull(minfo.getTaggedResponse(), "tagged response mismatched");
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.13</version>
+    <version>3.0.14</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.12</version>
+    <version>3.0.13</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
## Description
Expose additional data for select/examine command when QRESYNC is used



## Motivation and Context
When QRESYNC is enabled and select mailbox done, previously selected
mailbox can be closed implicitly which will be notified to client as
* OK [CLOSED]
When select/examine called caller need a way to validate the
OK response so expose the tagged response


## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
- [X ] My code follows the code style of this project.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.

