### PR TITLE
Add 'To' support to MessageNumberSet

### DIFF
--- a/core/src/main/java/com/yahoo/imapnio/async/data/MessageNumberSet.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/data/MessageNumberSet.java
@@ -79,12 +79,23 @@ public final class MessageNumberSet {
     }
 
     /**
+     * Enum for external use to denote last message in the set.
+     */
+    public enum ToMessage {
+        /** Last message to take. */
+        TO_MESSAGE
+    }
+
+    /**
      * Message sequence type. Whether an ending message is an absolute number or last message, or just last message.
      */
     private enum SequenceType {
 
         /** Sequence range ends with an absolute message sequence number, for example: 3:10. */
-        ABSOLUTE_END,
+        ABSOLUTE_RANGE,
+
+        /** Starts with the first message and has an absolute end, for example: *:10. */
+        FIRST_MESSAGE_ABSOLUTE_END,
 
         /** Ends with the last message in the mailbox, for example: 3:* . */
         LAST_MESSAGE_END,
@@ -109,7 +120,7 @@ public final class MessageNumberSet {
      * @param end ending message sequence or UID sequence
      */
     public MessageNumberSet(final long start, final long end) {
-        this(start, end, SequenceType.ABSOLUTE_END);
+        this(start, end, SequenceType.ABSOLUTE_RANGE);
     }
 
     /**
@@ -120,6 +131,16 @@ public final class MessageNumberSet {
      */
     public MessageNumberSet(final long start, @Nonnull final LastMessage lastMsgFlag) {
         this(start, start, SequenceType.LAST_MESSAGE_END);
+    }
+
+    /**
+     * Instantiates a {@link MessageNumberSet} that ends with given end starts with the first message.
+     *
+     * @param end last message sequence or UID sequence
+     * @param toMsgFlag flag to denote that it is the last message in mailbox
+     */
+    public MessageNumberSet(final long end, @Nonnull final ToMessage toMsgFlag) {
+        this(end, end, SequenceType.FIRST_MESSAGE_ABSOLUTE_END);
     }
 
     /**
@@ -242,6 +263,8 @@ public final class MessageNumberSet {
                 s.append('*');
             } else if (elem.seqType == SequenceType.LAST_MESSAGE_END) {
                 s.append(start).append(':').append('*');
+            } else if (elem.seqType == SequenceType.FIRST_MESSAGE_ABSOLUTE_END) {
+                s.append('*').append(':').append(end);
             } else if (end > start) {
                 s.append(start).append(':').append(end);
             } else { // end == start means only one element

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ByteBufWriter.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ByteBufWriter.java
@@ -43,23 +43,6 @@ final class ByteBufWriter extends Protocol {
     }
 
     /**
-     * Never used but must be implemented.
-     *
-     * @param host IMAP server host
-     * @param port IMAP server port
-     * @param props properties
-     * @param prefix prefix to prepend property keys
-     * @param isSSL is this an SSL connection
-     * @param logger logger
-     * @throws IOException on network failure
-     * @throws ProtocolException on IMAP protocol errors
-     */
-    private ByteBufWriter(final String host, final int port, final Properties props, final String prefix, final boolean isSSL,
-            final MailLogger logger) throws IOException, ProtocolException {
-        super(host, port, props, prefix, isSSL, logger);
-    }
-
-    /**
      * Returns a continuation response in order to avoid {@link com.sun.mail.iap.Argument} blocking on literal method to wait for server continuation.
      *
      * @return a continuation response

--- a/core/src/main/java/com/yahoo/imapnio/async/request/ByteBufWriter.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/request/ByteBufWriter.java
@@ -11,7 +11,6 @@ import com.sun.mail.iap.Protocol;
 import com.sun.mail.iap.ProtocolException;
 import com.sun.mail.iap.Response;
 import com.sun.mail.imap.protocol.IMAPResponse;
-import com.sun.mail.util.MailLogger;
 
 import io.netty.buffer.ByteBuf;
 

--- a/core/src/main/java/com/yahoo/imapnio/command/ProxyProtocol.java
+++ b/core/src/main/java/com/yahoo/imapnio/command/ProxyProtocol.java
@@ -29,31 +29,6 @@ public class ProxyProtocol extends Protocol {
     }
 
     /**
-     * Never used but must be implemented.
-     *
-     * @param host
-     *            IMAP server host
-     * @param port
-     *            IMAP server port
-     * @param props
-     *            properties
-     * @param prefix
-     *            prefix to prepend property keys
-     * @param isSSL
-     *            is this an SSL connection
-     * @param logger
-     *            logger
-     * @throws IOException
-     *             on network failure
-     * @throws ProtocolException
-     *             on IMAP protocol errors
-     */
-    private ProxyProtocol(final String host, final int port, final Properties props, final String prefix, final boolean isSSL,
-                    final MailLogger logger) throws IOException, ProtocolException {
-        super(host, port, props, prefix, isSSL, logger);
-    }
-
-    /**
      * Close.
      *
      * @throws IOException

--- a/core/src/main/java/com/yahoo/imapnio/command/ProxyProtocol.java
+++ b/core/src/main/java/com/yahoo/imapnio/command/ProxyProtocol.java
@@ -6,8 +6,6 @@ import java.io.OutputStream;
 import java.util.Properties;
 
 import com.sun.mail.iap.Protocol;
-import com.sun.mail.iap.ProtocolException;
-import com.sun.mail.util.MailLogger;
 
 /**
  * Class used to serialize IMAP commands. kraman

--- a/core/src/test/java/com/yahoo/imapnio/async/data/MessageNumberSetTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/MessageNumberSetTest.java
@@ -126,13 +126,15 @@ public class MessageNumberSetTest {
      */
     @Test
     public void testBuildString() throws ImapAsyncClientException {
-        final MessageNumberSet[] sets = new MessageNumberSet[3];
+        final MessageNumberSet[] sets = new MessageNumberSet[5];
 
         sets[0] = new MessageNumberSet(LastMessage.LAST_MESSAGE);
         sets[1] = new MessageNumberSet(1, 5);
         sets[2] = new MessageNumberSet(3, 3);
+        sets[3] = new MessageNumberSet(10, LastMessage.LAST_MESSAGE);
+        sets[4] = new MessageNumberSet(15, MessageNumberSet.ToMessage.TO_MESSAGE);
         Assert.assertNotNull(sets, "Should not be null");
-        Assert.assertEquals(MessageNumberSet.buildString(sets), "*,1:5,3", "Result mismatched.");
+        Assert.assertEquals(MessageNumberSet.buildString(sets), "*,1:5,3,10:*,*:15", "Result mismatched.");
     }
 
     /**

--- a/core/src/test/java/com/yahoo/imapnio/async/data/MessageNumberSetTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/data/MessageNumberSetTest.java
@@ -33,6 +33,16 @@ public class MessageNumberSetTest {
     }
 
     /**
+     * Tests constructor where ends with specific message and starts with the first message and converting it to string.
+     */
+    @Test
+    public void testConstructorWithEndStartWithFirst() {
+        final MessageNumberSet msgSet = new MessageNumberSet(100, MessageNumberSet.ToMessage.TO_MESSAGE);
+        Assert.assertNotNull(msgSet, "Should not be null");
+        Assert.assertEquals(MessageNumberSet.buildString(new MessageNumberSet[] { msgSet }), "*:100", "Result mismatched.");
+    }
+
+    /**
      * Tests constructor where it has only one message and converting it to string.
      */
     @Test

--- a/core/src/test/java/com/yahoo/imapnio/command/ArgumentTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/command/ArgumentTest.java
@@ -69,7 +69,34 @@ public class ArgumentTest {
         final Argument args = new Argument();
         args.append(searchSeq.generateSequence(term, MimeUtility.javaCharset(charset)));
 
-        args.writeAtom(msgIds);
+        args.addLiteral(msgIds);
+
+        final String searchStr = args.toString();
+        Assert.assertEquals(searchStr, "SUBJECT {4+}\r\nￎﾩￎﾩ 1:5", "result mismatched.");
+    }
+
+    /**
+     * Tests constructor and toString() method with null character set.
+     *
+     * @throws IOException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testConstructorAddStringAndToStringNoneNullCharset() throws SearchException, IOException {
+
+        final SearchSequence searchSeq = new SearchSequence();
+        // message id
+        final String msgIds = "1:5";
+
+        // charset
+        final String charset = "UTF-8";
+
+        // SearchTerm
+        final SubjectTerm term = new SubjectTerm("ΩΩ");
+        final Argument args = new Argument();
+        args.append(searchSeq.generateSequence(term, MimeUtility.javaCharset(charset)));
+
+        args.addString(msgIds);
 
         final String searchStr = args.toString();
         Assert.assertEquals(searchStr, "SUBJECT {4+}\r\nￎﾩￎﾩ 1:5", "result mismatched.");


### PR DESCRIPTION
## Description
MessageNumberSet does not support `To` range.

## Motivation and Context
We need to express `*:42` kind of ranges.

## How Has This Been Tested?
A test was added.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

