### PR TITLE
Support other returned options in LIST STATUS command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>4.3.0</version>
+      <version>4.3.1</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/test/java/com/yahoo/imapnio/async/request/ListStatusCommandTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/request/ListStatusCommandTest.java
@@ -49,15 +49,31 @@ public class ListStatusCommandTest {
     public void testGetCommandLineOnePattern1() throws ImapAsyncClientException, IllegalArgumentException, IllegalAccessException {
         final String[] someItems = { "UIDVALIDITY", "UIDNEXT", "MESSAGES", "HIGHESTMODSEQ", "UNSEEN", "RECENT", "MAILBOXID" };
         final String[] patterns = { "*" };
-        final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
-        Assert.assertEquals(cmd.getCommandLine(),
-                "LIST \"\" (\"*\") RETURN (STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT MAILBOXID))\r\n",
-                "Expected result mismatched.");
+        {
+            final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
+            Assert.assertEquals(cmd.getCommandLine(),
+                    "LIST \"\" (\"*\") RETURN (STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT MAILBOXID))\r\n",
+                    "Expected result mismatched.");
 
-        cmd.cleanup();
-        // Verify if cleanup happened correctly.
-        for (final Field field : fieldsToCheck) {
-            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+        // test with other options
+        {
+            final String[] otherOpts = { "SPECIAL-USE", "CHILDREN" };
+            final ImapRequest cmd = new ListStatusCommand("", patterns, otherOpts, someItems);
+            Assert.assertEquals(cmd.getCommandLine(),
+                    "LIST \"\" (\"*\") RETURN (SPECIAL-USE CHILDREN STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT MAILBOXID))\r\n",
+                    "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
         }
     }
 
@@ -72,13 +88,28 @@ public class ListStatusCommandTest {
     public void testGetCommandLineOnePatternEscapeChars() throws ImapAsyncClientException, IllegalArgumentException, IllegalAccessException {
         final String[] someItems = { "UIDVALIDITY", "UIDNEXT" };
         final String[] patterns = { "&iber " };
-        final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
-        Assert.assertEquals(cmd.getCommandLine(), "LIST \"\" (\"&-iber \") RETURN (STATUS (UIDVALIDITY UIDNEXT))\r\n", "Expected result mismatched.");
+        {
+            final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
+            Assert.assertEquals(cmd.getCommandLine(), "LIST \"\" (\"&-iber \") RETURN (STATUS (UIDVALIDITY UIDNEXT))\r\n",
+                    "Expected result mismatched.");
 
-        cmd.cleanup();
-        // Verify if cleanup happened correctly.
-        for (final Field field : fieldsToCheck) {
-            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+        {
+            final String[] otherOpts = { "SPECIAL-USE" };
+            final ImapRequest cmd = new ListStatusCommand("", patterns, otherOpts, someItems);
+            Assert.assertEquals(cmd.getCommandLine(), "LIST \"\" (\"&-iber \") RETURN (SPECIAL-USE STATUS (UIDVALIDITY UIDNEXT))\r\n",
+                    "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
         }
     }
 
@@ -93,15 +124,30 @@ public class ListStatusCommandTest {
     public void testGetCommandLineMultiPatterns() throws ImapAsyncClientException, IllegalArgumentException, IllegalAccessException {
         final String[] someItems = { "UIDVALIDITY", "UIDNEXT", "MESSAGES", "HIGHESTMODSEQ", "UNSEEN", "RECENT" };
         final String[] patterns = { "INBOX", "Drafts", "Sent/%" };
-        final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
-        Assert.assertEquals(cmd.getCommandLine(),
-                "LIST \"\" (\"INBOX\" \"Drafts\" \"Sent/%\") RETURN (STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n",
-                "Expected result mismatched.");
+        {
+            final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
+            Assert.assertEquals(cmd.getCommandLine(),
+                    "LIST \"\" (\"INBOX\" \"Drafts\" \"Sent/%\") RETURN (STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n",
+                    "Expected result mismatched.");
 
-        cmd.cleanup();
-        // Verify if cleanup happened correctly.
-        for (final Field field : fieldsToCheck) {
-            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+        {
+            // lower cases
+            final String[] otherOpts = { "SPECIAL-UsE", "children" };
+            final ImapRequest cmd = new ListStatusCommand("", patterns, otherOpts, someItems);
+            Assert.assertEquals(cmd.getCommandLine(), "LIST \"\" (\"INBOX\" \"Drafts\" \"Sent/%\") RETURN (SPECIAL-UsE children STATUS "
+                    + "(UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n", "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
         }
     }
 
@@ -116,15 +162,28 @@ public class ListStatusCommandTest {
     public void testGetCommandLineMultiPatternsEscapeChars() throws ImapAsyncClientException, IllegalArgumentException, IllegalAccessException {
         final String[] someItems = { "UIDVALIDITY", "UIDNEXT", "MESSAGES", "HIGHESTMODSEQ", "UNSEEN", "RECENT" };
         final String[] patterns = { "*", "&iber ", "Drafts", "Sent/%" };
-        final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
-        Assert.assertEquals(cmd.getCommandLine(),
-                "LIST \"\" (\"*\" \"&-iber \" \"Drafts\" \"Sent/%\") RETURN (STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n",
-                "Expected result mismatched.");
+        {
+            final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
+            Assert.assertEquals(cmd.getCommandLine(), "LIST \"\" (\"*\" \"&-iber \" \"Drafts\" \"Sent/%\") RETURN (STATUS "
+                    + "(UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n", "Expected result mismatched.");
 
-        cmd.cleanup();
-        // Verify if cleanup happened correctly.
-        for (final Field field : fieldsToCheck) {
-            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+        {
+            final String[] otherOpts = { "SPECIAL-USE" };
+            final ImapRequest cmd = new ListStatusCommand("", patterns, otherOpts, someItems);
+            Assert.assertEquals(cmd.getCommandLine(), "LIST \"\" (\"*\" \"&-iber \" \"Drafts\" \"Sent/%\") RETURN (SPECIAL-USE STATUS "
+                    + "(UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n", "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
         }
     }
 
@@ -139,15 +198,29 @@ public class ListStatusCommandTest {
     public void testGetCommandLineMultiPatternsNoneAsciiChars() throws ImapAsyncClientException, IllegalArgumentException, IllegalAccessException {
         final String[] someItems = { "UIDVALIDITY", "UIDNEXT", "MESSAGES", "HIGHESTMODSEQ", "UNSEEN", "RECENT" };
         final String[] patterns = { "ΩΩ", "Sent/%" };
-        final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
-        Assert.assertEquals(cmd.getCommandLine(),
-                "LIST \"\" (\"&A6kDqQ-\" \"Sent/%\") RETURN (STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n",
-                "Expected result mismatched.");
+        {
+            final ImapRequest cmd = new ListStatusCommand("", patterns, someItems);
+            Assert.assertEquals(cmd.getCommandLine(),
+                    "LIST \"\" (\"&A6kDqQ-\" \"Sent/%\") RETURN (STATUS (UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n",
+                    "Expected result mismatched.");
 
-        cmd.cleanup();
-        // Verify if cleanup happened correctly.
-        for (final Field field : fieldsToCheck) {
-            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+        {
+            final String[] otherOpts = { "SUBSCRIBED", "SPECIAL-USE", "CHILDREN" };
+            final ImapRequest cmd = new ListStatusCommand("", patterns, otherOpts, someItems);
+            Assert.assertEquals(cmd.getCommandLine(), "LIST \"\" (\"&A6kDqQ-\" \"Sent/%\") RETURN (SUBSCRIBED SPECIAL-USE CHILDREN STATUS "
+                    + "(UIDVALIDITY UIDNEXT MESSAGES HIGHESTMODSEQ UNSEEN RECENT))\r\n", "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
         }
     }
 

--- a/core/src/test/java/com/yahoo/imapnio/async/response/ImapResponseMapperTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/response/ImapResponseMapperTest.java
@@ -1141,24 +1141,21 @@ public class ImapResponseMapperTest {
      *
      * @throws IOException will not throw
      * @throws ProtocolException will not throw
+     * @throws ImapAsyncClientException will not throw
      */
     @Test
-    public void testParseToIdResultNameAbsent() throws IOException, ProtocolException {
+    public void testParseToIdResultNameAbsent() throws IOException, ProtocolException, ImapAsyncClientException {
         final ImapResponseMapper mapper = new ImapResponseMapper();
         final IMAPResponse[] content = new IMAPResponse[2];
+        // sun java mail library 1.5.5 has bug fix in readStringList() to return 0 length array instead of 1 length with a null element
+
         content[0] = new IMAPResponse("* ID () \n");
         content[1] = new IMAPResponse("a042 OK ID command completed");
 
         // verify the result
-        ImapAsyncClientException cause = null;
-        try {
-            mapper.readValue(content, IdResult.class);
-        } catch (final ImapAsyncClientException e) {
-            cause = e;
-        }
+        final IdResult id = mapper.readValue(content, IdResult.class);
         // verify the result
-        Assert.assertNotNull(cause, "cause mismatched.");
-        Assert.assertEquals(cause.getFailureType(), FailureType.INVALID_INPUT, "Failure type mismatched.");
+        Assert.assertNotNull(id, "result mismatched.");
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>
@@ -113,7 +113,7 @@
             <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>javax.mail</artifactId>
-                <version>1.5.2</version>
+                <version>1.5.5</version>
             </dependency>
             <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request has 2 changes:
1. allows callers to pass other returned options when requesting a list status command.
2. Bump up dependent library: javax.mail to 1.5.5 (release at 2015) to obtain bugs fixes.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

