### PR TITLE
Fix response total bytes counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>5.0.0</version>
+      <version>5.0.1</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImpl.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImpl.java
@@ -509,7 +509,7 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
         final ImapRequest currentCmd = curEntry.getRequest();
         final Collection<IMAPResponse> responses = curEntry.getResponses();
         responses.add(serverResponse);
-        curEntry.recordResponseBytes(serverResponse.toString().getBytes(StandardCharsets.US_ASCII).length + 2);
+        curEntry.recordResponseBytes(serverResponse.toString().getBytes(StandardCharsets.US_ASCII).length);
 
         if (isDebugEnabled()) { // logging all server responses when enabled
             logger.debug(SERVER_LOG_REC, sessionId, getUserInfo(), serverResponse.toString());

--- a/core/src/test/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImplTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImplTest.java
@@ -180,9 +180,8 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getRequestTotalBytes(),
                     "a1 AUTHENTICATE PLAIN\r\n".getBytes(StandardCharsets.US_ASCII).length + clientResponseLength,
                     "request bytes mismatched.");
-            Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    "+\r\n".getBytes(StandardCharsets.US_ASCII).length
-                            + "a1 OK AUTHENTICATE completed\r\n".getBytes(StandardCharsets.US_ASCII).length,
+            Assert.assertEquals(asyncResp.getResponseTotalBytes(), serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length
+                    + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
             // verify no log messages
             Mockito.verify(logger, Mockito.times(0)).debug(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
@@ -266,10 +265,10 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getRequestTotalBytes(), "a2 CAPABILITY\r\n".getBytes(StandardCharsets.US_ASCII).length,
                     "request bytes mismatched.");
             Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    (serverResp1String + "\r\n").getBytes(StandardCharsets.US_ASCII).length
-                            + (serverRespJunkString + "\r\n").getBytes(StandardCharsets.US_ASCII).length
-                            + (anotherTaggedRespString + "\r\n").getBytes(StandardCharsets.US_ASCII).length
-                            + (serverResp2String + "\r\n").getBytes(StandardCharsets.US_ASCII).length,
+                    serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverRespJunk.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + anotherTaggedResp.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -407,10 +406,9 @@ public class ImapAsyncSessionImplTest {
                             + "*\r\n".getBytes(StandardCharsets.US_ASCII).length,
                     "request bytes mismatched.");
             Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    "+\r\n".getBytes(StandardCharsets.US_ASCII).length
-                            + "+ eyJzdGF0dXMiOiI0MDAiLCJzY2hlbWVzIjoiQmVhcmVyIiwic2NvcGUiOiJodHRwczovL21haWwuZ29vZ2xlLmNvbS8ifQ==\r\n"
-                                    .getBytes(StandardCharsets.US_ASCII).length
-                            + "a1 BAD Invalid SASL argument.\r\n".getBytes(StandardCharsets.US_ASCII).length,
+                    serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverResp3.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -527,10 +525,8 @@ public class ImapAsyncSessionImplTest {
                             + clientResponse.getBytes(StandardCharsets.US_ASCII).length
                             + "\r\n".getBytes(StandardCharsets.US_ASCII).length,
                     "request bytes mismatched.");
-            Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    "+ eyJzdGF0dXMiOiI0MDAiLCJzY2hlbWVzIjoiQmVhcmVyIiwic2NvcGUiOiJodHRwczovL21haWwuZ29vZ2xlLmNvbS8ifQ==\r\n"
-                            .getBytes(StandardCharsets.US_ASCII).length
-                            + "a1 BAD Invalid SASL argument.\r\n".getBytes(StandardCharsets.US_ASCII).length,
+            Assert.assertEquals(asyncResp.getResponseTotalBytes(), serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length
+                    + serverResp3.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -632,8 +628,8 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getRequestTotalBytes(),
                     "a1 AUTHENTICATE PLAIN\r\n".getBytes(StandardCharsets.US_ASCII).length + clientResponseLength, "request bytes mismatched.");
             Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    "+\r\n".getBytes(StandardCharsets.US_ASCII).length
-                            + "a1 OK AUTHENTICATE completed\r\n".getBytes(StandardCharsets.US_ASCII).length,
+                    serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -692,7 +688,7 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getCommandType(), ImapRFCSupportedCommandType.COMPRESS, "command type mismatched.");
             Assert.assertEquals(asyncResp.getRequestTotalBytes(), "a2 COMPRESS DEFLATE\r\n".getBytes(StandardCharsets.US_ASCII).length,
                     "request bytes mismatched.");
-            Assert.assertEquals(asyncResp.getResponseTotalBytes(), "a2 OK Success\r\n".getBytes(StandardCharsets.US_ASCII).length,
+            Assert.assertEquals(asyncResp.getResponseTotalBytes(), serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -801,8 +797,8 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getRequestTotalBytes(),
                     "a1 AUTHENTICATE PLAIN\r\n".getBytes(StandardCharsets.US_ASCII).length + clientResponseLength, "request bytes mismatched.");
             Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    "+\r\n".getBytes(StandardCharsets.US_ASCII).length
-                            + "a1 OK AUTHENTICATE completed\r\n".getBytes(StandardCharsets.US_ASCII).length,
+                    serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -863,7 +859,7 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getCommandType(), ImapRFCSupportedCommandType.COMPRESS, "command type mismatched.");
             Assert.assertEquals(asyncResp.getRequestTotalBytes(), "a2 COMPRESS DEFLATE\r\n".getBytes(StandardCharsets.US_ASCII).length,
                     "request bytes mismatched.");
-            Assert.assertEquals(asyncResp.getResponseTotalBytes(), "a2 OK Success\r\n".getBytes(StandardCharsets.US_ASCII).length,
+            Assert.assertEquals(asyncResp.getResponseTotalBytes(), serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -971,8 +967,8 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getRequestTotalBytes(),
                     "a1 AUTHENTICATE PLAIN\r\n".getBytes(StandardCharsets.US_ASCII).length + clientResponseLength, "request bytes mismatched.");
             Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    "+\r\n".getBytes(StandardCharsets.US_ASCII).length
-                            + "a1 OK AUTHENTICATE completed\r\n".getBytes(StandardCharsets.US_ASCII).length,
+                    serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -1031,7 +1027,7 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getCommandType(), ImapRFCSupportedCommandType.COMPRESS, "command type mismatched.");
             Assert.assertEquals(asyncResp.getRequestTotalBytes(), "a2 COMPRESS DEFLATE\r\n".getBytes(StandardCharsets.US_ASCII).length,
                     "request bytes mismatched.");
-            Assert.assertEquals(asyncResp.getResponseTotalBytes(), "a2 OK Success\r\n".getBytes(StandardCharsets.US_ASCII).length,
+            Assert.assertEquals(asyncResp.getResponseTotalBytes(), serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages
@@ -1528,9 +1524,9 @@ public class ImapAsyncSessionImplTest {
         Assert.assertEquals(asyncResp.getCommandType(), ImapRFCSupportedCommandType.IDLE, "command type mismatched.");
         Assert.assertEquals(asyncResp.getRequestTotalBytes(), "a1 IDLE\r\n".getBytes(StandardCharsets.US_ASCII).length, "request bytes mismatched.");
         Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                "+ idling\r\n".getBytes(StandardCharsets.US_ASCII).length + "* 2 EXPUNGE\r\n".getBytes(StandardCharsets.US_ASCII).length
-                        + "* 3 EXISTS\r\n".getBytes(StandardCharsets.US_ASCII).length
-                        + "a1 OK IDLE terminated\r\n".getBytes(StandardCharsets.US_ASCII).length,
+                serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length
+                        + serverResp3.toString().getBytes(StandardCharsets.US_ASCII).length
+                        + serverResp4.toString().getBytes(StandardCharsets.US_ASCII).length,
                 "response bytes mismatched.");
 
         // queue is empty now, calling terminateCommand again
@@ -1883,8 +1879,8 @@ public class ImapAsyncSessionImplTest {
             Assert.assertEquals(asyncResp.getRequestTotalBytes(),
                     "a1 AUTHENTICATE PLAIN\r\n".getBytes(StandardCharsets.US_ASCII).length + clientResponseLength, "request bytes mismatched.");
             Assert.assertEquals(asyncResp.getResponseTotalBytes(),
-                    "+\r\n".getBytes(StandardCharsets.US_ASCII).length
-                            + "a1 OK AUTHENTICATE completed\r\n".getBytes(StandardCharsets.US_ASCII).length,
+                    serverResp1.toString().getBytes(StandardCharsets.US_ASCII).length
+                            + serverResp2.toString().getBytes(StandardCharsets.US_ASCII).length,
                     "response bytes mismatched.");
 
             // verify logging messages

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
Fix response total bytes

## Description
Fix response total bytes counting. Remove extra +2 in response bytes counting. ImapResponse.toString() already has \r\n inside so no need to add +2 for length. 

## Motivation and Context
Fix response total bytes counting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

