### PR TITLE
Record latency of imap commands in imap nio client.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>5.0.13</version>
+        <version>5.0.14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImpl.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImpl.java
@@ -150,6 +150,9 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
         /** Number of bytes in response. */
         private int responseTotalBytes;
 
+        /** Request start time. */
+        private long requestStartTimeInMillis;
+
         /**
          * Initializes a newly created {@link ImapCommandEntry} object so that it can handle the command responses and determine whether the request
          * is done.
@@ -158,9 +161,10 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
          * @param future ImapFuture instance
          * @param tag the tag associated with this command
          * @param requestTotalBytes request total bytes
+         * @param requestStartTimeInMillis request start time
          */
         ImapCommandEntry(@Nonnull final ImapRequest cmd, @Nonnull final ImapFuture<ImapAsyncResponse> future, @Nonnull final String tag,
-                final int requestTotalBytes) {
+                final int requestTotalBytes, final long requestStartTimeInMillis) {
             this.cmd = cmd;
             this.state = CommandState.REQUEST_IN_PREPARATION;
             this.responses = (cmd.getStreamingResponsesQueue() != null) ? cmd.getStreamingResponsesQueue()
@@ -170,6 +174,7 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
             this.requestSentTime = 0;
             this.requestTotalBytes = requestTotalBytes;
             this.responseTotalBytes = 0;
+            this.requestStartTimeInMillis = requestStartTimeInMillis;
         }
 
         /**
@@ -233,7 +238,8 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
          * @param sb StringBuilder instance to output the entry information
          */
         public void debugInfo(@Nonnull final StringBuilder sb) {
-            sb.append(CMD_TAG).append(tag).append(CMD_TYPE).append(getRequest().getCommandType()).append(CMD_SENT).append(getRequestSentTime());
+            sb.append(CMD_TAG).append(tag).append(CMD_TYPE).append(getRequest().getCommandType()).append(CMD_SENT)
+                    .append(getRequestStartTimeInMillis());
         }
 
         /**
@@ -259,6 +265,13 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
          */
         public void recordResponseBytes(final int length) {
             responseTotalBytes += length;
+        }
+
+        /**
+         * @return request start time.
+         */
+        public long getRequestStartTimeInMillis() {
+            return requestStartTimeInMillis;
         }
 
         /**
@@ -335,7 +348,7 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
         final ImapFuture<ImapAsyncResponse> cmdFuture = new ImapFuture<ImapAsyncResponse>();
         final String tag = getNextTag();
         final int requestTotalBytes = tag.getBytes(StandardCharsets.US_ASCII).length + SPACE_LENGTH + command.getCommandLineBytes().readableBytes();
-        requestsQueue.add(new ImapCommandEntry(command, cmdFuture, tag, requestTotalBytes));
+        requestsQueue.add(new ImapCommandEntry(command, cmdFuture, tag, requestTotalBytes, clock.millis()));
 
         final ByteBuf buf = Unpooled.buffer();
 
@@ -357,6 +370,7 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
     /**
      * @return true if channel is closed; false otherwise
      */
+    @Override
     public boolean isChannelClosed() {
         return !channelRef.get().isActive();
     }
@@ -560,8 +574,9 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
                     }
                 }
                 // see rfc3501, page 63 for details, since we always give a tagged command, response completion should be the first tagged response
+                final long totalTimeElapsedInMillis = clock.millis() - curEntry.getRequestStartTimeInMillis();
                 final ImapAsyncResponse doneResponse = new ImapAsyncResponse(curEntry.getRequest().getCommandType(), curEntry.getRequestTotalBytes(),
-                        curEntry.getResponseTotalBytes(), responses);
+                        curEntry.getResponseTotalBytes(), responses, totalTimeElapsedInMillis);
                 removeFirstEntry();
                 curEntry.getFuture().done(doneResponse);
                 return;

--- a/core/src/main/java/com/yahoo/imapnio/async/response/ImapAsyncResponse.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/response/ImapAsyncResponse.java
@@ -18,6 +18,8 @@ public class ImapAsyncResponse {
     private int responseTotalBytes;
     /** List of IMAPResponse lines. */
     private Collection<IMAPResponse> responses;
+    /** Total time elapsed by command in millis. */
+    private long totalTimeElapsedInMillis;
 
     /**
      * Initializes an {@link ImapAsyncResponse} object.
@@ -26,13 +28,15 @@ public class ImapAsyncResponse {
      * @param requestTotalBytes number of bytes in request
      * @param responseTotalBytes number of bytes in response
      * @param responses list of response lines
+     * @param totalTimeElapsedInMillis total time elapsed in millis
      */
     public ImapAsyncResponse(final ImapCommandType commandType, final int requestTotalBytes, final int responseTotalBytes,
-            final Collection<IMAPResponse> responses) {
+            final Collection<IMAPResponse> responses, final long totalTimeElapsedInMillis) {
         this.responses = responses;
         this.commandType = commandType;
         this.requestTotalBytes = requestTotalBytes;
         this.responseTotalBytes = responseTotalBytes;
+        this.totalTimeElapsedInMillis = totalTimeElapsedInMillis;
     }
 
     /**
@@ -61,5 +65,12 @@ public class ImapAsyncResponse {
      */
     public Collection<IMAPResponse> getResponseLines() {
         return responses;
+    }
+
+    /**
+     * @return total time elapsed in milli seconds.
+     */
+    public long getTotalTimeElapsed() {
+        return totalTimeElapsedInMillis;
     }
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/client/ImapFutureTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/client/ImapFutureTest.java
@@ -59,8 +59,9 @@ public class ImapFutureTest {
         capas.put("SASL-IR", Collections.singletonList("SASL-IR"));
         final ImapRequest imapRequest = new AuthXoauth2Command("username", "token", new Capability(capas));
         final int requestTotalBytes = "a1".getBytes(StandardCharsets.US_ASCII).length + 1 + imapRequest.getCommandLineBytes().readableBytes();
+        final long totalElapsedTime = 1234L;
         imapAsyncResp = new ImapAsyncResponse(imapRequest.getCommandType(), requestTotalBytes,
-                oneImapResponse.toString().getBytes(StandardCharsets.US_ASCII).length + 2, imapResponses);
+                oneImapResponse.toString().getBytes(StandardCharsets.US_ASCII).length + 2, imapResponses, totalElapsedTime);
     }
 
     /**
@@ -544,6 +545,22 @@ public class ImapFutureTest {
         final ImapFuture<ImapAsyncResponse> imapFuture = new ImapFuture<ImapAsyncResponse>();
         final long mockTimeoutForFailure = 1L;
         imapFuture.get(mockTimeoutForFailure, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Test total time elapsed by a command.
+     *
+     * @throws TimeoutException should not happen
+     * @throws ExecutionException should not happen
+     * @throws InterruptedException should not happen
+     */
+    @Test
+    public void testTotalTimeElapsed() throws InterruptedException, ExecutionException, TimeoutException {
+        final ImapFuture<ImapAsyncResponse> imapFuture = new ImapFuture<ImapAsyncResponse>();
+        imapFuture.done(imapAsyncResp);
+        final ImapAsyncResponse result = imapFuture.get(TIME_OUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getTotalTimeElapsed(), 1234L);
     }
 
 }

--- a/core/src/test/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImplTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/internal/ImapAsyncSessionImplTest.java
@@ -224,6 +224,7 @@ public class ImapAsyncSessionImplTest {
             // verify that future should be done now
             Assert.assertTrue(future.isDone(), "isDone() should be true now");
             final ImapAsyncResponse asyncResp = future.get(FUTURE_GET_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            Assert.assertEquals(asyncResp.getTotalTimeElapsed(), 2L);
 
             final Collection<IMAPResponse> lines = asyncResp.getResponseLines();
             Assert.assertEquals(lines.size(), 4, "responses count mismatched.");
@@ -1366,7 +1367,7 @@ public class ImapAsyncSessionImplTest {
         final ImapAsyncClientException asynEx = (ImapAsyncClientException) cause;
         Assert.assertEquals(asynEx.getFailureType(), FailureType.CHANNEL_DISCONNECTED, "Failure type mismatched.");
         Assert.assertEquals(asynEx.getMessage(),
-                "failureType=CHANNEL_DISCONNECTED,sId=123456,uId=Argentinosaurus@long.enough,cmdTag:a1,cmdType:CAPABILITY,cmdSent:0",
+                "failureType=CHANNEL_DISCONNECTED,sId=123456,uId=Argentinosaurus@long.enough,cmdTag:a1,cmdType:CAPABILITY,cmdSent:1",
                 "Error message mismatched.");
 
         // verify logging messages

--- a/core/src/test/java/com/yahoo/imapnio/async/response/ImapAsyncResponseTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/async/response/ImapAsyncResponseTest.java
@@ -34,7 +34,9 @@ public class ImapAsyncResponseTest {
         final IMAPResponse oneImapResponse = new IMAPResponse("a1 OK CAPABILITY completed");
         imapResponses.add(oneImapResponse);
         final int responseTotalBytes = oneImapResponse.toString().getBytes(StandardCharsets.US_ASCII).length + 2;
-        final ImapAsyncResponse resp = new ImapAsyncResponse(imapRequest.getCommandType(), requestTotalBytes, responseTotalBytes, imapResponses);
+        final long elapsedTime = 1234L;
+        final ImapAsyncResponse resp = new ImapAsyncResponse(imapRequest.getCommandType(), requestTotalBytes, responseTotalBytes, imapResponses,
+                elapsedTime);
 
         Assert.assertEquals(resp.getCommandType(), imapRequest.getCommandType(), "command type mismatched.");
         Assert.assertEquals(resp.getRequestTotalBytes(), requestTotalBytes, "request bytes length mismatched.");
@@ -42,5 +44,6 @@ public class ImapAsyncResponseTest {
         final Collection<IMAPResponse> actual = resp.getResponseLines();
         Assert.assertEquals(actual, imapResponses, "result mismatched.");
         Assert.assertEquals(actual.iterator().next(), oneImapResponse, "result mismatched.");
+        Assert.assertEquals(resp.getTotalTimeElapsed(), elapsedTime);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.13</version>
+    <version>5.0.14</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
Record latency of imap commands in imap nio client.

## Description
Need to know the latency of each imap command executed by the imap-nio client. Changes include recording start end end time of an imap command and storing the latency in ImapAsyncResponse.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

