### PR TITLE
Use LinedBasedFrameDecoder to decode the response from the channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, update your project's pom.xml file dependencies, as follows:
   <dependency>
       <groupId>com.yahoo.imapnio</groupId>
       <artifactId>imapnio.core</artifactId>
-      <version>5.0.14</version>
+      <version>5.0.15</version>
   </dependency>
 ```
 Finally, import the relevant classes and use this library according to the usage section below.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.imapnio</groupId>
         <artifactId>imapnio</artifactId>
-        <version>5.0.14</version>
+        <version>5.0.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/imapnio/client/ImapClientRespReader.java
+++ b/core/src/main/java/com/yahoo/imapnio/client/ImapClientRespReader.java
@@ -7,16 +7,16 @@ import com.sun.mail.util.ASCIIUtility;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.DelimiterBasedFrameDecoder;
+import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.util.ReferenceCountUtil;
 
 /**
- * Basic response reader, read response from channel and decode based on line delimiter, also could handle IMAP literal response.
+ * Basic response reader, read response from channel and decode based on line, also could handle IMAP literal response.
  *
  * @author kaituo
  *
  */
-public class ImapClientRespReader extends DelimiterBasedFrameDecoder {
+public class ImapClientRespReader extends LineBasedFrameDecoder {
 
     /** Constant for 4. */
     private static final int FOUR = 4;
@@ -36,16 +36,13 @@ public class ImapClientRespReader extends DelimiterBasedFrameDecoder {
     /** Literal response buffer. */
     private ByteBuf literalBuf;
 
-    /** IMAP response line delimiter, carriage return - new line. */
-    private static final ByteBuf[] DELIMITER = new ByteBuf[] { Unpooled.wrappedBuffer(new byte[] { '\r', '\n' }) };
-
     /**
      * Constructor of IMAP client response reader.
      *
      * @param maxLineLength maximum response line length
      */
     public ImapClientRespReader(final int maxLineLength) {
-        super(maxLineLength, false, DELIMITER);
+        super(maxLineLength, false, true);
         literalCount = -1;
     }
 
@@ -64,7 +61,6 @@ public class ImapClientRespReader extends DelimiterBasedFrameDecoder {
      */
     @Override
     protected Object decode(final ChannelHandlerContext ctx, final ByteBuf inputBuf) throws Exception {
-
         while (inputBuf.readableBytes() > 0) {
 
             if (literalCount <= 0) { // LINE mode - read until CRLF
@@ -162,5 +158,4 @@ public class ImapClientRespReader extends DelimiterBasedFrameDecoder {
             return -1;
         }
     }
-
 }

--- a/core/src/test/java/com/yahoo/imapnio/client/ImapClientRespReaderTest.java
+++ b/core/src/test/java/com/yahoo/imapnio/client/ImapClientRespReaderTest.java
@@ -176,7 +176,7 @@ public class ImapClientRespReaderTest {
         Assert.assertNotNull(resultBuf2, "Should return null because not reaching a line yet");
         Assert.assertEquals(inputBuf2.readableBytes(), 0, "should exhaust readable bytes");
         final String result = resultBuf2.toString(StandardCharsets.US_ASCII);
-        Assert.assertEquals(result, "NO CRLF YET, and here u go with CRLF!\r\n", "decode() result mismatched.");
+        Assert.assertEquals(result, literalResponse2, "decode() result mismatched.");
     }
 
     /**
@@ -230,8 +230,10 @@ public class ImapClientRespReaderTest {
         final ByteBuf inputBuf1 = Unpooled.copiedBuffer(responseBytes1, 0, responseBytes1.length);
 
         final ByteBuf resultBuf1 = (ByteBuf) respReader.decode(null, inputBuf1);
-        Assert.assertEquals(inputBuf1.readerIndex(), 0, "ReaderIndex should not be moved.");
-        Assert.assertNull(resultBuf1, "Should return null because not seeing CRLF yet");
+        Assert.assertEquals(inputBuf1.readerIndex(), 12, "ReaderIndex should not be moved.");
+        Assert.assertNotNull(resultBuf1, "Should return null because not seeing CRLF yet");
+        final String result2 = resultBuf1.toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(result2, literalResponse1, "response doesn't match");
     }
 
     /**
@@ -247,13 +249,20 @@ public class ImapClientRespReaderTest {
         final ByteBuf inputBuf1 = Unpooled.copiedBuffer(responseBytes1, 0, responseBytes1.length);
 
         final ByteBuf resultBuf1 = (ByteBuf) respReader.decode(null, inputBuf1);
-        Assert.assertEquals(inputBuf1.readerIndex(), 0, "ReaderIndex should not be moved.");
-        Assert.assertNull(resultBuf1, "Should return null because not seeing CRLF yet");
+        Assert.assertEquals(inputBuf1.readerIndex(), 12, "ReaderIndex should not be moved.");
+        Assert.assertNotNull(resultBuf1, "Should return null because not seeing CRLF yet");
+
+        final String result2 = resultBuf1.toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(result2, "Hello\rWorld\n", "response doesn't match");
+
+        final ByteBuf resultBuf2 = (ByteBuf) respReader.decode(null, inputBuf1);
+        Assert.assertEquals(inputBuf1.readerIndex(), 12, "ReaderIndex should not be moved.");
+        Assert.assertNull(resultBuf2, "Should return null because not seeing CRLF yet");
     }
 
     /**
      * Tests 1st buffer ends with CR without LF, the reader index should not change. 2nd time LF comes, it should return complete result.
-     * 
+     *
      * @throws Exception not for this test
      */
     @Test
@@ -303,13 +312,20 @@ public class ImapClientRespReaderTest {
         Assert.assertNull(resultBuf1, "Should return null because not seeing CRLF yet");
 
         final ByteBuf resultBuf2 = (ByteBuf) respReader.decode(null, inputBuf2);
-        Assert.assertEquals(inputBuf2.readerIndex(), 0, "ReaderIndex should not be moved.");
-        Assert.assertNull(resultBuf2, "Should return null because not seeing CRLF yet");
+        Assert.assertEquals(inputBuf2.readerIndex(), 12, "ReaderIndex should not be moved.");
+        Assert.assertNotNull(resultBuf2, "Should return null because not seeing CRLF yet");
 
         final ByteBuf resultBuf3 = (ByteBuf) respReader.decode(null, inputBuf3);
-        Assert.assertEquals(inputBuf3.readableBytes(), 0, "readableBytes should be exhausted.");
+        Assert.assertEquals(inputBuf3.readableBytes(), 28, "readableBytes should be exhausted.");
         Assert.assertNotNull(resultBuf3, "Should have data returned");
         final String result = resultBuf3.toString(StandardCharsets.US_ASCII);
-        Assert.assertEquals(result, literalResponse3, "decode() result mismatched.");
+        Assert.assertEquals(result, literalResponse2, "decode() result mismatched.");
+
+        final ByteBuf resultBuf4 = (ByteBuf) respReader.decode(null, inputBuf3);
+        Assert.assertEquals(inputBuf3.readableBytes(), 0, "readableBytes should be exhausted.");
+        Assert.assertNotNull(resultBuf4, "Should have data returned");
+        final String result2 = resultBuf4.toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(result2, ", and here u go with CRLF!\r\n", "decode() result mismatched.");
+
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.imapnio</groupId>
     <artifactId>imapnio</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.14</version>
+    <version>5.0.15</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/imapnio</url>
     <description>Parent POM file for imapnio project</description>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a CPU spike observed while using DelimiterBasedFrameDecoder with a large payload size. To mitigate this issue, we switch to using LineBasedFrameDecoder. This class seems to be more efficient because it simplifies the decoding process and improves performance significantly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

