### PR TITLE
[MAS-46399] Handling NPE on sync side

### DIFF
--- a/core/src/main/java/com/yahoo/imapnio/async/netty/ImapClientCommandRespHandler.java
+++ b/core/src/main/java/com/yahoo/imapnio/async/netty/ImapClientCommandRespHandler.java
@@ -38,7 +38,9 @@ public class ImapClientCommandRespHandler extends MessageToMessageDecoder<IMAPRe
 
     @Override
     public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
-        processor.handleChannelException(cause);
+        if (processor != null) {
+            processor.handleChannelException(cause);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Handling NPE on sync side

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cleanup() is invoked from channelInactive() and sets processor = null. During Netty pipeline teardown, channelInactive() may be called on this handler before exceptionCaught() (for example, if a decompression error is reported later or handler ordering differs). As a result, exceptionCaught() can be invoked after cleanup has already run and observe processor == null.

The if (processor != null) guard ensures that we do not call handleChannelException() after cleanup has completed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] All new and existing tests passed.

